### PR TITLE
Setting date for durationStatus to true null.

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -184,6 +184,8 @@ function updateStatus(): void {
 			//This value is based on the average calculated from various different scripts (see script_to_time.txt)
 			var secondcount = vscode.window.activeTextEditor.document.getText().replace(/ |\n|\t/g, "").length / 16.304;
 			var time = new Date(null);
+			time.setHours(0);
+			time.setMinutes(0);
 			time.setSeconds(secondcount);
 			durationStatus.text = padZero(time.getHours()) + ":" + padZero(time.getMinutes()) + ":" + padZero(time.getSeconds());
 		}


### PR DESCRIPTION
The way you had this before, the date(null) wasn't really creating a null date. It was creating a date based off the Unix epoch timestamp.

With my timezone difference (-5), the runtime hours was automatically being set to 19. (See Issue #1 )

These new two lines set the hours and minutes to zero before setting the seconds based on actual script length.