### PR TITLE
Fix npm audit issue in underscore.string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "betterfountain",
-	"version": "1.0.2",
+	"version": "1.1.2",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -28,13 +28,13 @@
 			"requires": {
 				"aw-liner": "0.0.2",
 				"aw-parser": "0.1.1",
-				"d3": "3.5.17",
-				"grunt": "1.0.3",
-				"handlebars": "4.0.12",
-				"jquery": "3.3.1",
-				"lodash": "4.17.11",
+				"d3": "^3.4.1",
+				"grunt": "~1.0.1",
+				"handlebars": "^4.0.6",
+				"jquery": "^3.1.1",
+				"lodash": "^4.17.4",
 				"protoplast": "2.0.3",
-				"stdio": "0.2.7",
+				"stdio": "^0.2.7",
 				"text": "github:requirejs/text#d04de4ffd7bf5ba6cb80cdca2d40d4f6f52a1b1f"
 			}
 		},
@@ -43,7 +43,7 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
 			"requires": {
-				"color-convert": "1.9.3"
+				"color-convert": "^1.9.0"
 			}
 		},
 		"argparse": {
@@ -51,7 +51,7 @@
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
 			"integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
 			"requires": {
-				"sprintf-js": "1.0.3"
+				"sprintf-js": "~1.0.2"
 			},
 			"dependencies": {
 				"sprintf-js": {
@@ -91,7 +91,7 @@
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"requires": {
-				"balanced-match": "1.0.0",
+				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
 			}
 		},
@@ -110,8 +110,8 @@
 			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
 			"integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
 			"requires": {
-				"camelcase": "2.1.1",
-				"map-obj": "1.0.1"
+				"camelcase": "^2.0.0",
+				"map-obj": "^1.0.0"
 			}
 		},
 		"chalk": {
@@ -119,9 +119,9 @@
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
 			"integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
 			"requires": {
-				"ansi-styles": "3.2.1",
-				"escape-string-regexp": "1.0.5",
-				"supports-color": "5.5.0"
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
 			}
 		},
 		"coffeescript": {
@@ -163,7 +163,7 @@
 			"resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
 			"integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
 			"requires": {
-				"array-find-index": "1.0.2"
+				"array-find-index": "^1.0.1"
 			}
 		},
 		"d3": {
@@ -176,8 +176,8 @@
 			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
 			"integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
 			"requires": {
-				"get-stdin": "4.0.1",
-				"meow": "3.7.0"
+				"get-stdin": "^4.0.1",
+				"meow": "^3.3.0"
 			}
 		},
 		"decamelize": {
@@ -190,7 +190,7 @@
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
 			"requires": {
-				"is-arrayish": "0.2.1"
+				"is-arrayish": "^0.2.1"
 			}
 		},
 		"escape-string-regexp": {
@@ -218,8 +218,8 @@
 			"resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
 			"integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
 			"requires": {
-				"path-exists": "2.1.0",
-				"pinkie-promise": "2.0.1"
+				"path-exists": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"findup-sync": {
@@ -227,7 +227,7 @@
 			"resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz",
 			"integrity": "sha1-N5MKpdgWt3fANEXhlmzGeQpMCxY=",
 			"requires": {
-				"glob": "5.0.15"
+				"glob": "~5.0.0"
 			},
 			"dependencies": {
 				"glob": {
@@ -235,11 +235,11 @@
 					"resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
 					"integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
 					"requires": {
-						"inflight": "1.0.6",
-						"inherits": "2.0.3",
-						"minimatch": "3.0.4",
-						"once": "1.4.0",
-						"path-is-absolute": "1.0.1"
+						"inflight": "^1.0.4",
+						"inherits": "2",
+						"minimatch": "2 || 3",
+						"once": "^1.3.0",
+						"path-is-absolute": "^1.0.0"
 					}
 				}
 			}
@@ -264,12 +264,12 @@
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
 			"integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
 			"requires": {
-				"fs.realpath": "1.0.0",
-				"inflight": "1.0.6",
-				"inherits": "2.0.3",
-				"minimatch": "3.0.4",
-				"once": "1.4.0",
-				"path-is-absolute": "1.0.1"
+				"fs.realpath": "^1.0.0",
+				"inflight": "^1.0.4",
+				"inherits": "2",
+				"minimatch": "^3.0.2",
+				"once": "^1.3.0",
+				"path-is-absolute": "^1.0.0"
 			}
 		},
 		"graceful-fs": {
@@ -282,23 +282,23 @@
 			"resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
 			"integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
 			"requires": {
-				"coffeescript": "1.10.0",
-				"dateformat": "1.0.12",
-				"eventemitter2": "0.4.14",
-				"exit": "0.1.2",
-				"findup-sync": "0.3.0",
-				"glob": "7.0.6",
-				"grunt-cli": "1.2.0",
-				"grunt-known-options": "1.1.1",
-				"grunt-legacy-log": "2.0.0",
-				"grunt-legacy-util": "1.1.1",
-				"iconv-lite": "0.4.24",
-				"js-yaml": "3.5.5",
-				"minimatch": "3.0.4",
-				"mkdirp": "0.5.1",
-				"nopt": "3.0.6",
-				"path-is-absolute": "1.0.1",
-				"rimraf": "2.6.2"
+				"coffeescript": "~1.10.0",
+				"dateformat": "~1.0.12",
+				"eventemitter2": "~0.4.13",
+				"exit": "~0.1.1",
+				"findup-sync": "~0.3.0",
+				"glob": "~7.0.0",
+				"grunt-cli": "~1.2.0",
+				"grunt-known-options": "~1.1.0",
+				"grunt-legacy-log": "~2.0.0",
+				"grunt-legacy-util": "~1.1.1",
+				"iconv-lite": "~0.4.13",
+				"js-yaml": "~3.5.2",
+				"minimatch": "~3.0.2",
+				"mkdirp": "~0.5.1",
+				"nopt": "~3.0.6",
+				"path-is-absolute": "~1.0.0",
+				"rimraf": "~2.6.2"
 			},
 			"dependencies": {
 				"grunt-cli": {
@@ -306,10 +306,10 @@
 					"resolved": "https://registry.npmjs.org/grunt-cli/-/grunt-cli-1.2.0.tgz",
 					"integrity": "sha1-VisRnrsGndtGSs4oRVAb6Xs1tqg=",
 					"requires": {
-						"findup-sync": "0.3.0",
-						"grunt-known-options": "1.1.1",
-						"nopt": "3.0.6",
-						"resolve": "1.1.7"
+						"findup-sync": "~0.3.0",
+						"grunt-known-options": "~1.1.0",
+						"nopt": "~3.0.6",
+						"resolve": "~1.1.0"
 					}
 				}
 			}
@@ -324,10 +324,10 @@
 			"resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz",
 			"integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
 			"requires": {
-				"colors": "1.1.2",
-				"grunt-legacy-log-utils": "2.0.1",
-				"hooker": "0.2.3",
-				"lodash": "4.17.11"
+				"colors": "~1.1.2",
+				"grunt-legacy-log-utils": "~2.0.0",
+				"hooker": "~0.2.3",
+				"lodash": "~4.17.5"
 			}
 		},
 		"grunt-legacy-log-utils": {
@@ -335,8 +335,8 @@
 			"resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz",
 			"integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
 			"requires": {
-				"chalk": "2.4.1",
-				"lodash": "4.17.11"
+				"chalk": "~2.4.1",
+				"lodash": "~4.17.10"
 			}
 		},
 		"grunt-legacy-util": {
@@ -344,13 +344,13 @@
 			"resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz",
 			"integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
 			"requires": {
-				"async": "1.5.2",
-				"exit": "0.1.2",
-				"getobject": "0.1.0",
-				"hooker": "0.2.3",
-				"lodash": "4.17.11",
-				"underscore.string": "3.3.4",
-				"which": "1.3.1"
+				"async": "~1.5.2",
+				"exit": "~0.1.1",
+				"getobject": "~0.1.0",
+				"hooker": "~0.2.3",
+				"lodash": "~4.17.10",
+				"underscore.string": "~3.3.4",
+				"which": "~1.3.0"
 			}
 		},
 		"handlebars": {
@@ -358,10 +358,10 @@
 			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.12.tgz",
 			"integrity": "sha512-RhmTekP+FZL+XNhwS1Wf+bTTZpdLougwt5pcgA1tuz6Jcx0fpH/7z0qd71RKnZHBCxIRBHfBOnio4gViPemNzA==",
 			"requires": {
-				"async": "2.6.1",
-				"optimist": "0.6.1",
-				"source-map": "0.6.1",
-				"uglify-js": "3.4.9"
+				"async": "^2.5.0",
+				"optimist": "^0.6.1",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4"
 			},
 			"dependencies": {
 				"async": {
@@ -369,7 +369,7 @@
 					"resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
 					"integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
 					"requires": {
-						"lodash": "4.17.11"
+						"lodash": "^4.17.10"
 					}
 				}
 			}
@@ -394,7 +394,7 @@
 			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"requires": {
-				"safer-buffer": "2.1.2"
+				"safer-buffer": ">= 2.1.2 < 3"
 			}
 		},
 		"indent-string": {
@@ -402,7 +402,7 @@
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
 			"integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
 			"requires": {
-				"repeating": "2.0.1"
+				"repeating": "^2.0.0"
 			}
 		},
 		"inflight": {
@@ -410,8 +410,8 @@
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"requires": {
-				"once": "1.4.0",
-				"wrappy": "1.0.2"
+				"once": "^1.3.0",
+				"wrappy": "1"
 			}
 		},
 		"inherits": {
@@ -429,7 +429,7 @@
 			"resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
 			"integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
 			"requires": {
-				"builtin-modules": "1.1.1"
+				"builtin-modules": "^1.0.0"
 			}
 		},
 		"is-finite": {
@@ -437,7 +437,7 @@
 			"resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
 			"integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
 			"requires": {
-				"number-is-nan": "1.0.1"
+				"number-is-nan": "^1.0.0"
 			}
 		},
 		"is-utf8": {
@@ -460,8 +460,8 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.5.5.tgz",
 			"integrity": "sha1-A3fDgBfKvHMisNH7zSWkkWQfL74=",
 			"requires": {
-				"argparse": "1.0.10",
-				"esprima": "2.7.3"
+				"argparse": "^1.0.2",
+				"esprima": "^2.6.0"
 			}
 		},
 		"load-json-file": {
@@ -469,11 +469,11 @@
 			"resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
 			"integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"parse-json": "2.2.0",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1",
-				"strip-bom": "2.0.0"
+				"graceful-fs": "^4.1.2",
+				"parse-json": "^2.2.0",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0",
+				"strip-bom": "^2.0.0"
 			}
 		},
 		"lodash": {
@@ -486,8 +486,8 @@
 			"resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
 			"integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
 			"requires": {
-				"currently-unhandled": "0.4.1",
-				"signal-exit": "3.0.2"
+				"currently-unhandled": "^0.4.1",
+				"signal-exit": "^3.0.0"
 			}
 		},
 		"map-obj": {
@@ -500,16 +500,16 @@
 			"resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
 			"integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
 			"requires": {
-				"camelcase-keys": "2.1.0",
-				"decamelize": "1.2.0",
-				"loud-rejection": "1.6.0",
-				"map-obj": "1.0.1",
-				"minimist": "1.2.0",
-				"normalize-package-data": "2.4.0",
-				"object-assign": "4.1.1",
-				"read-pkg-up": "1.0.1",
-				"redent": "1.0.0",
-				"trim-newlines": "1.0.0"
+				"camelcase-keys": "^2.0.0",
+				"decamelize": "^1.1.2",
+				"loud-rejection": "^1.0.0",
+				"map-obj": "^1.0.1",
+				"minimist": "^1.1.3",
+				"normalize-package-data": "^2.3.4",
+				"object-assign": "^4.0.1",
+				"read-pkg-up": "^1.0.1",
+				"redent": "^1.0.0",
+				"trim-newlines": "^1.0.0"
 			}
 		},
 		"minimatch": {
@@ -517,7 +517,7 @@
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"requires": {
-				"brace-expansion": "1.1.11"
+				"brace-expansion": "^1.1.7"
 			}
 		},
 		"minimist": {
@@ -545,7 +545,7 @@
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
 			"integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
 			"requires": {
-				"abbrev": "1.1.1"
+				"abbrev": "1"
 			}
 		},
 		"normalize-package-data": {
@@ -553,10 +553,10 @@
 			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
 			"integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
 			"requires": {
-				"hosted-git-info": "2.7.1",
-				"is-builtin-module": "1.0.0",
-				"semver": "5.5.1",
-				"validate-npm-package-license": "3.0.4"
+				"hosted-git-info": "^2.1.4",
+				"is-builtin-module": "^1.0.0",
+				"semver": "2 || 3 || 4 || 5",
+				"validate-npm-package-license": "^3.0.1"
 			}
 		},
 		"number-is-nan": {
@@ -574,7 +574,7 @@
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"requires": {
-				"wrappy": "1.0.2"
+				"wrappy": "1"
 			}
 		},
 		"optimist": {
@@ -582,8 +582,8 @@
 			"resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
 			"integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
 			"requires": {
-				"minimist": "0.0.10",
-				"wordwrap": "0.0.3"
+				"minimist": "~0.0.1",
+				"wordwrap": "~0.0.2"
 			},
 			"dependencies": {
 				"minimist": {
@@ -598,7 +598,7 @@
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
 			"integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
 			"requires": {
-				"error-ex": "1.3.2"
+				"error-ex": "^1.2.0"
 			}
 		},
 		"path-exists": {
@@ -606,7 +606,7 @@
 			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
 			"integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
 			"requires": {
-				"pinkie-promise": "2.0.1"
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"path-is-absolute": {
@@ -619,9 +619,9 @@
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
 			"integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
 			"requires": {
-				"graceful-fs": "4.1.11",
-				"pify": "2.3.0",
-				"pinkie-promise": "2.0.1"
+				"graceful-fs": "^4.1.2",
+				"pify": "^2.0.0",
+				"pinkie-promise": "^2.0.0"
 			}
 		},
 		"pify": {
@@ -639,7 +639,7 @@
 			"resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
 			"integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
 			"requires": {
-				"pinkie": "2.0.4"
+				"pinkie": "^2.0.0"
 			}
 		},
 		"protoplast": {
@@ -652,9 +652,9 @@
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
 			"integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
 			"requires": {
-				"load-json-file": "1.1.0",
-				"normalize-package-data": "2.4.0",
-				"path-type": "1.1.0"
+				"load-json-file": "^1.0.0",
+				"normalize-package-data": "^2.3.2",
+				"path-type": "^1.0.0"
 			}
 		},
 		"read-pkg-up": {
@@ -662,8 +662,8 @@
 			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
 			"integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
 			"requires": {
-				"find-up": "1.1.2",
-				"read-pkg": "1.1.0"
+				"find-up": "^1.0.0",
+				"read-pkg": "^1.0.0"
 			}
 		},
 		"redent": {
@@ -671,8 +671,8 @@
 			"resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
 			"integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
 			"requires": {
-				"indent-string": "2.1.0",
-				"strip-indent": "1.0.1"
+				"indent-string": "^2.1.0",
+				"strip-indent": "^1.0.1"
 			}
 		},
 		"repeating": {
@@ -680,7 +680,7 @@
 			"resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
 			"integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
 			"requires": {
-				"is-finite": "1.0.2"
+				"is-finite": "^1.0.0"
 			}
 		},
 		"resolve": {
@@ -693,7 +693,7 @@
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
 			"integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
 			"requires": {
-				"glob": "7.0.6"
+				"glob": "^7.0.5"
 			}
 		},
 		"safer-buffer": {
@@ -721,8 +721,8 @@
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
 			"integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
 			"requires": {
-				"spdx-expression-parse": "3.0.0",
-				"spdx-license-ids": "3.0.1"
+				"spdx-expression-parse": "^3.0.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-exceptions": {
@@ -735,8 +735,8 @@
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
 			"integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
 			"requires": {
-				"spdx-exceptions": "2.1.0",
-				"spdx-license-ids": "3.0.1"
+				"spdx-exceptions": "^2.1.0",
+				"spdx-license-ids": "^3.0.0"
 			}
 		},
 		"spdx-license-ids": {
@@ -745,9 +745,9 @@
 			"integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w=="
 		},
 		"sprintf-js": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
-			"integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw="
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
 		},
 		"stdio": {
 			"version": "0.2.7",
@@ -759,7 +759,7 @@
 			"resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
 			"integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
 			"requires": {
-				"is-utf8": "0.2.1"
+				"is-utf8": "^0.2.0"
 			}
 		},
 		"strip-indent": {
@@ -767,7 +767,7 @@
 			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
 			"integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
 			"requires": {
-				"get-stdin": "4.0.1"
+				"get-stdin": "^4.0.1"
 			}
 		},
 		"supports-color": {
@@ -775,11 +775,12 @@
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"requires": {
-				"has-flag": "3.0.0"
+				"has-flag": "^3.0.0"
 			}
 		},
 		"text": {
-			"version": "github:requirejs/text#d04de4ffd7bf5ba6cb80cdca2d40d4f6f52a1b1f"
+			"version": "github:requirejs/text#d04de4ffd7bf5ba6cb80cdca2d40d4f6f52a1b1f",
+			"from": "text@github:requirejs/text#d04de4ffd7bf5ba6cb80cdca2d40d4f6f52a1b1f"
 		},
 		"trim-newlines": {
 			"version": "1.0.0",
@@ -798,17 +799,17 @@
 			"integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
 			"optional": true,
 			"requires": {
-				"commander": "2.17.1",
-				"source-map": "0.6.1"
+				"commander": "~2.17.1",
+				"source-map": "~0.6.1"
 			}
 		},
 		"underscore.string": {
-			"version": "3.3.4",
-			"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
-			"integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+			"version": "3.3.5",
+			"resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.5.tgz",
+			"integrity": "sha512-g+dpmgn+XBneLmXXo+sGlW5xQEt4ErkS3mgeN2GFbremYeMBSJKr9Wf2KJplQVaiPY/f7FN6atosWYNm9ovrYg==",
 			"requires": {
-				"sprintf-js": "1.1.1",
-				"util-deprecate": "1.0.2"
+				"sprintf-js": "^1.0.3",
+				"util-deprecate": "^1.0.2"
 			}
 		},
 		"util-deprecate": {
@@ -821,8 +822,8 @@
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
 			"requires": {
-				"spdx-correct": "3.0.0",
-				"spdx-expression-parse": "3.0.0"
+				"spdx-correct": "^3.0.0",
+				"spdx-expression-parse": "^3.0.0"
 			}
 		},
 		"which": {
@@ -830,7 +831,7 @@
 			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
 			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
 			"requires": {
-				"isexe": "2.0.0"
+				"isexe": "^2.0.0"
 			}
 		},
 		"wordwrap": {

--- a/package.json
+++ b/package.json
@@ -50,14 +50,16 @@
 			]
 		},
 		"views": {
-			"fountain-view":[{
-				"id": "fountain-outline",
-				"name": "Outline"
-			},
-			{
-				"id": "fountain-commands",
-				"name": "Commands"
-			}]
+			"fountain-view": [
+				{
+					"id": "fountain-outline",
+					"name": "Outline"
+				},
+				{
+					"id": "fountain-commands",
+					"name": "Commands"
+				}
+			]
 		},
 		"configuration": [
 			{


### PR DESCRIPTION
Fixed using `npm audit fix`

Fixes:
```
npm audit --fix

                       === npm audit security report ===

# Run  npm update underscore.string --depth 4  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ underscore.string                                            │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ afterwriting                                                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ afterwriting > grunt > grunt-legacy-util > underscore.string │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://nodesecurity.io/advisories/745                       │
└───────────────┴──────────────────────────────────────────────────────────────┘
```