### PR TITLE
Show (CONT'D) in editor next to repeated character names

### DIFF
--- a/client/src/afterwriting-parser.ts
+++ b/client/src/afterwriting-parser.ts
@@ -1,5 +1,5 @@
 import * as helpers from "./helpers";
-var regex: { [index: string]: RegExp } = {
+export var regex: { [index: string]: RegExp } = {
     title_page: /(title|credit|author[s]?|source|notes|draft date|date|watermark|contact|copyright)\:.*/i,
 
     section: /^(#+)(?: *)(.*)/,

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -227,20 +227,20 @@ export function activate(context: ExtensionContext) {
 		if (!activeEditor) {
 			return;
 		}
-        const regEx = new RegExp(afterparser.regex["character"], "gm");
+		const regEx = new RegExp(afterparser.regex["character"], "gm");
 		const text = activeEditor.document.getText();
 		const contdNames: vscode.DecorationOptions[] = [];
 		let match : RegExpExecArray;
 		let prevMatch : RegExpExecArray;
 
 		while (match = regEx.exec(text)) {
-            if (prevMatch && match[0] === prevMatch[0]) {
-                const startPos = activeEditor.document.positionAt(match.index);
-                const endPos = activeEditor.document.positionAt(match.index + match[0].length);
-                const decoration = { range: new vscode.Range(startPos, endPos) };
-                contdNames.push(decoration);
-            }
-            prevMatch = match;
+			if (prevMatch && match[0] === prevMatch[0]) {
+				const startPos = activeEditor.document.positionAt(match.index);
+				const endPos = activeEditor.document.positionAt(match.index + match[0].length);
+				const decoration = { range: new vscode.Range(startPos, endPos) };
+				contdNames.push(decoration);
+			}
+			prevMatch = match;
 		}
 		activeEditor.setDecorations(contdDecorator, contdNames);
 	}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -218,7 +218,8 @@ export function activate(context: ExtensionContext) {
 	//Create a decorator type that we use to show CONT'D markings
 	const contdDecorator = vscode.window.createTextEditorDecorationType({
 		after: {
-			contentText: ' (CONT\'D)'
+			contentText: ' (CONT\'D)',
+			color:new vscode.ThemeColor("editorLineNumber.foreground")
 		}
 	});
 	

--- a/package.json
+++ b/package.json
@@ -63,9 +63,20 @@
 		},
 		"configuration": [
 			{
-				"title": "Fountain PDF Export",
+				"title": "Better Fountain",
 				"type": "object",
 				"properties": {
+					"fountain.pdf.contdMode":{
+						"type":"string",
+						"enum": ["Auto-add to PDF (every time)", "Auto-add to PDF (page breaks only)", "No"],
+						"description": "The way CONT'D is added",
+						"default": "No"
+					},
+					"fountain.pdf.contdText":{
+						"type":"string",
+						"default":"CONT'D",
+						"description": "The text to be used for dialogue continuity (CONT'D)"
+					},
 					"fountain.pdf.emboldenSceneHeaders": {
 						"type": "boolean",
 						"default": false,


### PR DESCRIPTION
Partially fixes #19 (it doesn't show it in the live preview or exported PDFs)