### PR TITLE
Final draft style character autocompletion for dialogues

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,12 +157,12 @@
 					},
 					"fountain.pdf.previewTheme": {
 						"type": "string",
-						"enum":[
+						"enum": [
 							"vscode",
 							"paper"
 						],
 						"description": "The theme to be used in the live preview",
-						"default":"vscode"
+						"default": "vscode"
 					},
 					"fountain.pdf.sceneNumbers": {
 						"type": "string",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -687,8 +687,8 @@ class MyCompletionProvider implements vscode.CompletionItemProvider {
 		// Dialogue autocomplete
 		else if (multipleCharactersExist && currentLineIsEmpty && previousLineIsEmpty) {
 			// Autocomplete with character name who spoke before the last one
-			const charWhoSpokeBeforeLast = findCharacterThatSpokeBeforeTheLast(document, position, fountainDocProps)
-			completes.push({label: charWhoSpokeBeforeLast, kind: vscode.CompletionItemKind.Text})
+			const charWhoSpokeBeforeLast = findCharacterThatSpokeBeforeTheLast(document, position, fountainDocProps);
+			completes.push({label: charWhoSpokeBeforeLast, kind: vscode.CompletionItemKind.Text});
 		}
 		//Scene header autocomplete
 		else if (fountainDocProps.sceneLines.indexOf(position.line) > -1) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,19 +1,42 @@
 import * as vscode from "vscode";
 import { FountainStructureProperties } from "./extension";
 
+/**
+ * Trims character extensions, for example the parantheses part in `JOE (on the radio)`
+ */
+export const trimCharacterExtension = (character: string): string => character.replace(/( \([A-z0-9 '\-.()]+\))*(\s*\^*)?$/, "");
+
+/**
+ * Trims the `@` symbol necesary in character names if they contain lower-case letters, i.e. `@McCONNOR`
+ */
+const trimCharacterForceSymbol = (character: string): string => character.replace(/^@/, "");
+
+/**
+ * Character names containing lowercase letters need to be prefixed with an `@` symbol
+ */
+export const addForceSymbolToCharacter = (characterName: string): string => {
+	const containsLowerCase = (text: string): boolean =>(/[a-z]/.test(text));
+	return containsLowerCase(characterName) ? `@${characterName}` : characterName;
+}
+
 export const findCharacterThatSpokeBeforeTheLast = (
 	document: vscode.TextDocument,
 	position: vscode.Position,
 	fountainDocProps: FountainStructureProperties,
-): string => {
+	): string => {
+
+	const isAlreadyMentionedCharacter = (text: string): boolean => fountainDocProps.characters.has(text);
+
 	let characterBeforeLast = "";
 	let lineToInspect = 1;
 	let foundLastCharacter = false;
 	do {
 		const beginningOfLineToInspect = new vscode.Position(position.line - lineToInspect, 0);
 		const endOfLineToInspect = new vscode.Position(position.line - (lineToInspect - 1), 0);
-		const potentialCharacterLine = document.getText(new vscode.Range(beginningOfLineToInspect, endOfLineToInspect)).trimRight();
-		if (fountainDocProps.characters.has(potentialCharacterLine)) {
+		let potentialCharacterLine = document.getText(new vscode.Range(beginningOfLineToInspect, endOfLineToInspect)).trimRight();
+		potentialCharacterLine = trimCharacterExtension(potentialCharacterLine);
+		potentialCharacterLine = trimCharacterForceSymbol(potentialCharacterLine);
+		if (isAlreadyMentionedCharacter(potentialCharacterLine)) {
 			if (foundLastCharacter) {
 				characterBeforeLast = potentialCharacterLine;
 			} else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,26 @@
+import * as vscode from "vscode";
+import { FountainStructureProperties } from "./extension";
+
+export const findCharacterThatSpokeBeforeTheLast = (
+	document: vscode.TextDocument,
+	position: vscode.Position,
+	fountainDocProps: FountainStructureProperties,
+): string => {
+	let characterBeforeLast = "";
+	let lineToInspect = 1;
+	let foundLastCharacter = false;
+	do {
+		const potentialCharacterLine = document.getText(new vscode.Range(new vscode.Position(position.line - lineToInspect, 0), position)).split('\n')[0].trim()
+		if (fountainDocProps.characters.has(potentialCharacterLine)) {
+			if (foundLastCharacter) {
+				characterBeforeLast = potentialCharacterLine;
+			} else {
+				foundLastCharacter = true;
+			}
+		}
+		lineToInspect++;
+	} while (!characterBeforeLast)
+
+	return characterBeforeLast;
+}
+

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,7 @@ export const findCharacterThatSpokeBeforeTheLast = (
 	let lineToInspect = 1;
 	let foundLastCharacter = false;
 	do {
-		const potentialCharacterLine = document.getText(new vscode.Range(new vscode.Position(position.line - lineToInspect, 0), position)).split('\n')[0].trim()
+		const potentialCharacterLine = document.getText(new vscode.Range(new vscode.Position(position.line - lineToInspect, 0), position)).split('\n')[0].trim();
 		if (fountainDocProps.characters.has(potentialCharacterLine)) {
 			if (foundLastCharacter) {
 				characterBeforeLast = potentialCharacterLine;
@@ -19,7 +19,7 @@ export const findCharacterThatSpokeBeforeTheLast = (
 			}
 		}
 		lineToInspect++;
-	} while (!characterBeforeLast)
+	} while (!characterBeforeLast);
 
 	return characterBeforeLast;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,9 @@ export const findCharacterThatSpokeBeforeTheLast = (
 	let lineToInspect = 1;
 	let foundLastCharacter = false;
 	do {
-		const potentialCharacterLine = document.getText(new vscode.Range(new vscode.Position(position.line - lineToInspect, 0), position)).split('\n')[0].trim();
+		const beginningOfLineToInspect = new vscode.Position(position.line - lineToInspect, 0);
+		const endOfLineToInspect = new vscode.Position(position.line - (lineToInspect - 1), 0);
+		const potentialCharacterLine = document.getText(new vscode.Range(beginningOfLineToInspect, endOfLineToInspect)).trimRight();
 		if (fountainDocProps.characters.has(potentialCharacterLine)) {
 			if (foundLastCharacter) {
 				characterBeforeLast = potentialCharacterLine;


### PR DESCRIPTION
The industry standard software Final Draft has a very useful feature when writing dialogue: when jumping to a new line, it automatically suggests the character that spoke before the previous one. That way, when we have a dialogue between two characters MARY and TOBY, Final Draft knows pretty precisely that after TOBY spoke, we will probably want to write another line where MARY replies.

Here is a video which shows how this works in Final Draft: http://recordit.co/M68funBX2U

This pull requests introduces a feature which aims to emulate this by using autocompletes. A video showing how this looks: http://recordit.co/ehGmSTJAAW