### PR TITLE
Fix underlines not being syntax highlighted

### DIFF
--- a/syntaxes/fountain.tmlanguage
+++ b/syntaxes/fountain.tmlanguage
@@ -352,13 +352,13 @@
          <key>match</key>
          <string>^\s*(&gt;[^<\n\r]*|[A-Z ]+ TO:)$</string>
       </dict>
-      
+
       <!-- Text markup -->
       <key>markup</key>
       <dict>
          <key>patterns</key>
          <array>
-         
+
             <dict>
                <key>name</key>
                <string>markup.code</string>
@@ -393,11 +393,60 @@
 
             <dict>
                <key>name</key>
-               <string>markup.underline.fountain</string>
+               <string>markup.italic.fountain</string>
                <key>begin</key>
-               <string>_(?=.*_)</string>
+               <string>(?x)
+                  (\_)(?=\S)                        # Open
+                  (?=
+                     (
+                         &lt;[^&gt;]*+&gt;                     # HTML tags
+                       | (?&lt;raw&gt;`+)([^`]|(?!(?&lt;!`)\k&lt;raw&gt;(?!`))`)*+\k&lt;raw&gt;
+                                                   # Raw
+                       | \\[\\`*_{}\[\]()#.!+\-&gt;]?+         # Escapes
+                       | \[
+                        (
+                                (?&lt;square&gt;               # Named group
+                                 [^\[\]\\]            # Match most chars
+                                  | \\.                  # Escaped chars
+                                  | \[ \g&lt;square&gt;*+ \]      # Nested brackets
+                                )*+
+                           \]
+                           (
+                              (                    # Reference Link
+                                 [ ]?              # Optional space
+                                 \[[^\]]*+\]          # Ref name
+                              )
+                             | (                   # Inline Link
+                                 \(                # Opening paren
+                                    [ \t]*+           # Optional whtiespace
+                                    &lt;?(.*?)&gt;?         # URL
+                                    [ \t]*+           # Optional whtiespace
+                                    (              # Optional Title
+                                       (?&lt;title&gt;['"])
+                                       (.*?)
+                                       \k&lt;title&gt;
+                                    )?
+                                 \)
+                              )
+                           )
+                        )
+                       | \1\1                      # Must be bold closer
+                       | (?!(?&lt;=\S)\1).                  # Everything besides
+                                                   # style closer
+                     )++
+                     (?&lt;=\S)\1                        # Close
+                  )
+               </string>
+               <key>captures</key>
+                  <dict>
+                     <key>1</key>
+                     <dict>
+                     <key>name</key>
+                     <string>punctuation.definition.markup.italic.fountain</string>
+                     </dict>
+                  </dict>
                <key>end</key>
-               <string>_</string>
+               <string>(?&lt;=\S)(\1)((?!\1)|(?=\1\1))</string>
                <key>patterns</key>
                <array>
                   <dict>
@@ -603,7 +652,7 @@
          </array>
       </dict>
 
-      
+
    </dict>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request fixes a bug where in the text editor, underlined text (`_example_`) wasn't syntax highlighted.