### PR TITLE
Scene folding/collapsing functionality

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,8 +61,8 @@ const getLinePosition = (screenplayText: string, scene: string): number => {
 }
 
 export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
-    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\..+$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
-    const sceneHeadingRegex = /^(?:(?:\..+$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
+    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\.[^.].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
+    const sceneHeadingRegex = /^(?:(?:\.[^.].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
 	const headingsLinePositions: number[] = []
 
 	// Step 1: Create an array of scenes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,8 +61,8 @@ const getLinePosition = (screenplayText: string, scene: string): number => {
 }
 
 export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
-    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\.[[:alnum:]].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
-    const sceneHeadingRegex = /^(?:(?:\.[[:alnum:]].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
+    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\.[^.,;+=#@:\-<>?!|*/\\_].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
+    const sceneHeadingRegex = /^(?:(?:\.[^.,;+=#@:\-<>?!|*/\\_].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
 	const headingsLinePositions: number[] = []
 
 	// Step 1: Create an array of scenes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,8 +61,10 @@ const getLinePosition = (screenplayText: string, scene: string): number => {
 }
 
 export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
-    const sceneHeadingRegexLookAhead = /^(?=^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$)/mi
-    const sceneHeadingRegex = /^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$/i
+	const sceneHeadingRegexBase = "^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$"
+	const sceneHeadingRegex = new RegExp(sceneHeadingRegexBase, "i")
+	const sceneHeadingRegexLookAhead = new RegExp(`^(?=${sceneHeadingRegexBase})`, "mi")
+
 	const headingsLinePositions: number[] = []
 
 	// Step 1: Create an array of scenes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,8 +61,8 @@ const getLinePosition = (screenplayText: string, scene: string): number => {
 }
 
 export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
-    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\.[^.].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
-    const sceneHeadingRegex = /^(?:(?:\.[^.].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
+    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\.[[:alnum:]].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
+    const sceneHeadingRegex = /^(?:(?:\.[[:alnum:]].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
 	const headingsLinePositions: number[] = []
 
 	// Step 1: Create an array of scenes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,9 +50,7 @@ export const findCharacterThatSpokeBeforeTheLast = (
 }
 
 /**
- * Helper function to retrieve the position of a line in a text
- * @param screenplayText
- * @param scene
+ * Retrieves the line position of a substring inside a text with multiple lines
  */
 const getLinePosition = (screenplayText: string, scene: string): number => {
     const index = screenplayText.indexOf(scene)
@@ -69,8 +67,8 @@ export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRan
 
 	// Step 1: Create an array of scenes
     const scenes = screenplayText.split(sceneHeadingRegexLookAhead)
-	// Check if first string isn't actually a scene - remove in that case
-	// Is most likely the case if there are `Title: La La Land` attributes etc.
+	// Check if first string isn't actually a scene - remove in that case.
+	// This will happen if there are `Title: Frozen` attributes etc. on the top
     if (!sceneHeadingRegex.test(scenes[0])) {
         delete scenes[0]
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,8 +61,8 @@ const getLinePosition = (screenplayText: string, scene: string): number => {
 }
 
 export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
-    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\.[[:alnum:]].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
-    const sceneHeadingRegex = /^(?:(?:\.[[:alnum:]].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
+    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\.[^.].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
+    const sceneHeadingRegex = /^(?:(?:\.[^.].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
 	const headingsLinePositions: number[] = []
 
 	// Step 1: Create an array of scenes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,8 +61,8 @@ const getLinePosition = (screenplayText: string, scene: string): number => {
 }
 
 export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
-    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\.[^.].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
-    const sceneHeadingRegex = /^(?:(?:\.[^.].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
+    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\..+$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
+    const sceneHeadingRegex = /^(?:(?:\..+$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
 	const headingsLinePositions: number[] = []
 
 	// Step 1: Create an array of scenes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,8 +61,8 @@ const getLinePosition = (screenplayText: string, scene: string): number => {
 }
 
 export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
-    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\.[^.,;+=#@:\-<>?!|*/\\_].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
-    const sceneHeadingRegex = /^(?:(?:\.[^.,;+=#@:\-<>?!|*/\\_].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
+    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\.[[:alnum:]].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
+    const sceneHeadingRegex = /^(?:(?:\.[[:alnum:]].*$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
 	const headingsLinePositions: number[] = []
 
 	// Step 1: Create an array of scenes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,7 +81,6 @@ export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRan
 	// Step 3: Calculate the ranges of all scenes
     const sceneRanges: vscode.FoldingRange[] = []
     headingsLinePositions.reduce((prev, curr) => {
-		console.log({prev, curr})
 		sceneRanges.push(new vscode.FoldingRange(prev, curr - 2, 3))
         return curr
     })

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,8 +61,8 @@ const getLinePosition = (screenplayText: string, scene: string): number => {
 }
 
 export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
-    const sceneHeadingRegexLookAhead = /^(?=^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$)/mi
-    const sceneHeadingRegex = /^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$/i
+    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\..+$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
+    const sceneHeadingRegex = /^(?:(?:\..+$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
 	const headingsLinePositions: number[] = []
 
 	// Step 1: Create an array of scenes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,8 +61,8 @@ const getLinePosition = (screenplayText: string, scene: string): number => {
 }
 
 export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
-    const sceneHeadingRegexLookAhead = /^(?=^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$)/m
-    const sceneHeadingRegex = /^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$/
+    const sceneHeadingRegexLookAhead = /^(?=^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$)/mi
+    const sceneHeadingRegex = /^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$/i
 	const headingsLinePositions: number[] = []
 
 	// Step 1: Create an array of scenes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,41 +49,47 @@ export const findCharacterThatSpokeBeforeTheLast = (
 	return characterBeforeLast;
 }
 
-const getHeadingLinePosition = (screenplayText: string, scene: string): number => {
+/**
+ * Helper function to retrieve the position of a line in a text
+ * @param screenplayText
+ * @param scene
+ */
+const getLinePosition = (screenplayText: string, scene: string): number => {
     const index = screenplayText.indexOf(scene)
     const tempString = screenplayText.substring(0, index)
-    return tempString.split("\n").length
+    return tempString.split("\n").length - 1
 }
 
 export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
     const sceneHeadingRegexLookAhead = /^(?=(?:INT\.|EXT\.|INT\/EXT\.) .+$)/m
     const sceneHeadingRegex = /^(?:INT\. |EXT\. |INT\/EXT\. ).+$/
-    const headingsLinePositions: number[] = []
+	const headingsLinePositions: number[] = []
+
+	// Step 1: Create an array of scenes
     const scenes = screenplayText.split(sceneHeadingRegexLookAhead)
-    // Check if first string isn't actually a scene - remove in that case
+	// Check if first string isn't actually a scene - remove in that case
+	// Is most likely the case if there are `Title: La La Land` attributes etc.
     if (!sceneHeadingRegex.test(scenes[0])) {
         delete scenes[0]
     }
 
+	// Step 2: Update the array of line numbers of each scene (their beginning)
     scenes.forEach((scene) => {
-        headingsLinePositions.push(getHeadingLinePosition(screenplayText, scene))
+        headingsLinePositions.push(getLinePosition(screenplayText, scene))
     })
 
-    console.log(headingsLinePositions)
-
+	// Step 3: Calculate the ranges of all scenes
     const sceneRanges: vscode.FoldingRange[] = []
-
     headingsLinePositions.reduce((prev, curr) => {
 		console.log({prev, curr})
-		sceneRanges.push(new vscode.FoldingRange(prev - 1, curr - 3, 3))
+		sceneRanges.push(new vscode.FoldingRange(prev, curr - 2, 3))
         return curr
     })
-
     // Add last scene to sceneRanges array
     sceneRanges.push(
 		new vscode.FoldingRange(
-			headingsLinePositions[headingsLinePositions.length - 1] - 1,
-			screenplayText.split("\n").length - 2,
+			headingsLinePositions[headingsLinePositions.length - 1],
+			screenplayText.split("\n").length - 1,
 			3
 		)
 	)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -49,3 +49,44 @@ export const findCharacterThatSpokeBeforeTheLast = (
 	return characterBeforeLast;
 }
 
+const getHeadingLinePosition = (screenplayText: string, scene: string): number => {
+    const index = screenplayText.indexOf(scene)
+    const tempString = screenplayText.substring(0, index)
+    return tempString.split("\n").length
+}
+
+export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
+    const sceneHeadingRegexLookAhead = /^(?=(?:INT\.|EXT\.|INT\/EXT\.) .+$)/m
+    const sceneHeadingRegex = /^(?:INT\. |EXT\. |INT\/EXT\. ).+$/
+    const headingsLinePositions: number[] = []
+    const scenes = screenplayText.split(sceneHeadingRegexLookAhead)
+    // Check if first string isn't actually a scene - remove in that case
+    if (!sceneHeadingRegex.test(scenes[0])) {
+        delete scenes[0]
+    }
+
+    scenes.forEach((scene) => {
+        headingsLinePositions.push(getHeadingLinePosition(screenplayText, scene))
+    })
+
+    console.log(headingsLinePositions)
+
+    const sceneRanges: vscode.FoldingRange[] = []
+
+    headingsLinePositions.reduce((prev, curr) => {
+		console.log({prev, curr})
+		sceneRanges.push(new vscode.FoldingRange(prev - 1, curr - 3, 3))
+        return curr
+    })
+
+    // Add last scene to sceneRanges array
+    sceneRanges.push(
+		new vscode.FoldingRange(
+			headingsLinePositions[headingsLinePositions.length - 1] - 1,
+			screenplayText.split("\n").length - 2,
+			3
+		)
+	)
+
+    return sceneRanges
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,8 +61,8 @@ const getLinePosition = (screenplayText: string, scene: string): number => {
 }
 
 export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
-    const sceneHeadingRegexLookAhead = /^(?=(?:INT\.|EXT\.|INT\/EXT\.) .+$)/m
-    const sceneHeadingRegex = /^(?:INT\. |EXT\. |INT\/EXT\. ).+$/
+    const sceneHeadingRegexLookAhead = /^(?=^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$)/m
+    const sceneHeadingRegex = /^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$/
 	const headingsLinePositions: number[] = []
 
 	// Step 1: Create an array of scenes

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -61,8 +61,8 @@ const getLinePosition = (screenplayText: string, scene: string): number => {
 }
 
 export const getSceneFoldingRanges = (screenplayText: string): vscode.FoldingRange[] => {
-    const sceneHeadingRegexLookAhead = /^(?=^(?:(?:\..+$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n))/mi
-    const sceneHeadingRegex = /^(?:(?:\..+$\n\n)|(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$\n\n)/i
+    const sceneHeadingRegexLookAhead = /^(?=^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$)/mi
+    const sceneHeadingRegex = /^(?:INT|EXT|INT\/EXT|EST|I\/E|I\.\/E)(?: |\.).*$/i
 	const headingsLinePositions: number[] = []
 
 	// Step 1: Create an array of scenes


### PR DESCRIPTION
This pull request adds the functionality to fold/collapse scenes. The following video shows this in action: 
![Ciy4HFR1xr](https://user-images.githubusercontent.com/25436915/61161379-692fd600-a4fb-11e9-99da-82fc9eeb0656.gif)


To Do:

- [ ] A scene heading needs to be preceded by a blank line (already checking it) **and needs to be followed by a blank line**
- [ ] It is possible to force scene headings with a leading `.`
- [ ] Scene headings can only be forced with a leading `.` when the character after the `.` is either a letter or a number (alphanumeric)
  - [ ] Ellipsis lines (i.e. `... and then he kicked the ball`) should not be recognised as forced headings