### PR TITLE
Update https-proxy-agent to 2.2.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2682,9 +2682,9 @@
 			}
 		},
 		"https-proxy-agent": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
-			"integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz",
+			"integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
 			"dev": true,
 			"requires": {
 				"agent-base": "^4.3.0",


### PR DESCRIPTION
Updating https-proxy-agent to address a high vulnerability `npm audit` complains about:
```
High    Machine-In-The-Middle
Package    https-proxy-agent
Dependency of    vscode [dev]
Path    vscode > vscode-test > https-proxy-agent
More info    https://npmjs.com/advisories/1184
```