### PR TITLE
stats functions now process token list

### DIFF
--- a/src/afterwriting-parser.ts
+++ b/src/afterwriting-parser.ts
@@ -377,8 +377,8 @@ export var parse = function (original_script: string, cfg: any, generate_html: b
                     if(config.print_dialogue_numbers) AddDialogueNumberDecoration(thistoken)
                     thistoken.text = thistoken.text.replace(/^@/, "");
                     if (thistoken.text[thistoken.text.length - 1] === "^") {
-                        state = "dual_dialogue"
                         if (cfg.use_dual_dialogue) {
+                            state = "dual_dialogue"
                             // update last dialogue to be dual:left
                             var dialogue_tokens = ["dialogue", "character", "parenthetical"];
                             while (dialogue_tokens.indexOf(result.tokens[last_character_index].type) !== -1) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -292,7 +292,11 @@ export function activate(context: ExtensionContext) {
 		const statsPanel = vscode.window.createWebviewPanel('Screenplay statistics', 'Screenplay statistics', -1)
 		statsPanel.webview.html = `Calculating screenplay statistics...`
 		
-		const stats = retrieveScreenPlayStatistics(getEditor(activeFountainDocument()).document.getText())
+		var editor = getEditor(activeFountainDocument());
+		var config = getFountainConfig(activeFountainDocument());
+		var parsed = afterparser.parse(editor.document.getText(), config, false);
+
+		const stats = retrieveScreenPlayStatistics(editor.document.getText(), parsed)
 		const statsHTML = statsAsHtml(stats)
 		statsPanel.webview.html = statsHTML
 	}));

--- a/src/statistics.ts
+++ b/src/statistics.ts
@@ -39,20 +39,25 @@ type screenPlayStatistics = {
 
 const createCharacterStatistics = (parsed: parseoutput): dialogueStatisticPerCharacter[] => {
     const dialoguePieces: dialoguePiece[] = [];
-    for (var i=0; i<parsed.tokens.length;)
+    for (var i=0; i<parsed.tokens.length; i++)
     {
-        if (parsed.tokens[i++].type==="dialogue_begin")
+        while (i<parsed.tokens.length && parsed.tokens[i].type==="character")
         {
             const character = parsed.tokens[i].name()
             var speech = "";
-            while (parsed.tokens[i++].type!=="dialogue_end")
+            while (i++ && i<parsed.tokens.length)
             {
-                while (parsed.tokens[i].type==="dialogue")        
+                if (parsed.tokens[i].type==="dialogue")        
                 {
                     speech += parsed.tokens[i].text + " "
-                    i++;
                 }
+                else if (parsed.tokens[i].type==="character")
+                {
+                    break;
+                }
+                // else skip extensions / parenthesis / dialogue-begin/-end
             }
+            
             speech = speech.trim()
             dialoguePieces.push({
                 character,


### PR DESCRIPTION
Fixing issues I discovered playing with the Statistics.  including:

ERASMUS
Come back here!

@ ERASMUS
Come back here!

* above were being counted as separate characters
* having multiple parenthesis tokens per dialogue block was affecting character word count
* boneyarding affecting dialogue count and scene count

I've updated the stats functions to work off the parsed token list instead. This should also make future stats additions easier.