### PR TITLE
Removes line comments from language-configuration

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,5 @@
 {
     "comments": {
-                // symbol used for single line comment. Remove this entry if your language does not support line comments
-                "lineComment": "//",
                 // symbols used for start and end a block comment. Remove this entry if your language does not support block comments
                 "blockComment": [ "/*", "*/" ]
     },


### PR DESCRIPTION
Removes line comment as there really isn't support for line comments in the language documentation.
This should enable use of the comment shortcut to add boneyard marks (`Cmd/Ctrl + /`).

https://fountain.io/syntax#section-notes