### PR TITLE
regex fixes

### DIFF
--- a/src/afterwriting-parser.ts
+++ b/src/afterwriting-parser.ts
@@ -15,7 +15,7 @@ export const regex: { [index: string]: RegExp } = {
     section: /^[ \t]*(#+)(?: *)(.*)/,
     synopsis: /^[ \t]*(?:\=(?!\=+) *)(.*)/,
 
-    scene_heading: /^[ \t]*([.]|(?:[*]{0,3}_?)(?:int|ext|est|int[.]?\/ext|i[.]?\/e)[. ])(.+?)(#[-.0-9a-z]+#)?$/i,
+    scene_heading: /^[ \t]*([.](?![.])|(?:[*]{0,3}_?)(?:int|ext|est|int[.]?\/ext|i[.]?\/e)[. ])(.+?)(#[-.0-9a-z]+#)?$/i,
     scene_number: /#(.+)#/,
 
     transition: /^[ \t]*((?:FADE (?:TO BLACK|OUT)|CUT TO BLACK)\.|.+ TO\:|^TO\:$)|^(?:> *)(.+)/,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,7 +10,7 @@ import * as sceneNumbering from './scenenumbering';
 /**
  * Trims character extensions, for example the parantheses part in `JOE (on the radio)`
  */
-export const trimCharacterExtension = (character: string): string => character.replace(/( \([A-z0-9 '’\-.()]+\))*(\s*\^*)?$/, "");
+export const trimCharacterExtension = (character: string): string => character.replace(/( +\([A-z0-9 '’\-.()]+\))*(\s*\^*)?$/, "");
 
 /**
  * Trims the `@` symbol necesary in character names if they contain lower-case letters, i.e. `@McCONNOR`


### PR DESCRIPTION
Noticed that "..." was interpreted as a scene heading recently.

And the trimCharacterExtension needed to handle multiple spaces. (discovered using QuickPick for character highlight on Big Fish)