### PR TITLE
Outline fix96 and enhancement

### DIFF
--- a/src/providers/Outline.ts
+++ b/src/providers/Outline.ts
@@ -7,145 +7,148 @@ export class FountainOutlineTreeDataProvider implements vscode.TreeDataProvider<
 	public readonly onDidChangeTreeDataEmitter: vscode.EventEmitter<vscode.TreeItem | null> =
 		new vscode.EventEmitter<vscode.TreeItem | null>();
 	public readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | null> = this.onDidChangeTreeDataEmitter.event;
-	
+
 	treeView: vscode.TreeView<any>;
-	private latestReturnedNodes: Array<OutlineTreeItem>;
+	private treeRoot: OutlineTreeItem;
 
 	getTreeItem(element: vscode.TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
 		//throw new Error("Method not implemented.");
 		return element;
 	}
 	getChildren(element?: OutlineTreeItem): vscode.ProviderResult<any[]> {
-		var elements: OutlineTreeItem[] = [];
-
-		const pushSection = (token:afterparser.StructToken, lineNo:string) => {
-			var item = new OutlineTreeItem(token.text, token.id, +lineNo, element);
-			if (token.children != null && token.children.length > 0) {
-				item.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
-			}
-			if (token.synopses && token.synopses.length>0) {				
-				item.tooltip = token.synopses.map(s => s.synopsis).join('\n');				
-			}
-
-			if (token.section) {
-				var sectionDepth = Math.min((token.id.match(/\//g) || []).length, 5); //maximum depth is 5 - anything deeper is the same color as 5
-				item.iconPath = __filename + '/../../../assets/section' + sectionDepth + '.svg';
-			}
-			else {
-				item.iconPath = __filename + '/../../../assets/scene.svg';					
-			}
-			item.command = {
-				command: 'fountain.jumpto',
-				title: '',
-				arguments: [lineNo]
-			};
-            
-			// push synopses
-            if (token.synopses && token.synopses.length>0 && config.uiPersistence.outline_visibleSynopses) {
-				let loopCounterStart = 0;
-				// the loop counter starts allows us to not show the first synopse of a collapsible item (seeing as it's added to the description)
-				if(item.collapsibleState!=vscode.TreeItemCollapsibleState.None){
-					//If the item is collapsable, also render the synopse as a description (otherwise it's after all the children of the item)
-					item.description=token.synopses[0].synopsis;
-					loopCounterStart = 1;
-				}
-				elements.push(item);
-                for (let i = loopCounterStart; i < token.synopses.length; i++) {
-                    let synopse = new OutlineTreeItem("", "", token.synopses[i].line, element);
-					synopse.iconPath = __filename + '/../../../assets/synopse_offset.svg';
-					synopse.description = token.synopses[i].synopsis;
-					synopse.tooltip = synopse.description;
-                    synopse.command = {
-                        command: 'fountain.jumpto',
-                        title: '',
-                        arguments: [token.synopses[i].line]
-                    };
-                    elements.push(synopse);
-                }
-			}
-			else {
-				elements.push(item);
-			}
-
-			// push notes
-			if (token.notes && token.notes.length > 0 && config.uiPersistence.outline_visibleNotes) {
-                for (let i = 0; i < token.notes.length; i++) {
-					let item = new OutlineTreeItem("", "", token.notes[i].line, element);
-					item.iconPath = {
-						light: __filename + '/../../../assets/note_light_offset.svg',
-						dark: __filename + '/../../../assets/note_dark_offset.svg'
-					};
-					item.description = token.notes[i].note;
-					item.tooltip = item.description;
-					item.command = {
-                        command: 'fountain.jumpto',
-                        title: '',
-                        arguments: [token.notes[i].line]
-                    };
-                    elements.push(item);
-                }
-			}
-		}
-
-		const structure = activeParsedDocument().properties.structure;
-
-		if (element == null) {
-			// push in the top level sections (Acts) or Scenes outside of Acts
-			for (let index = 0; index < structure.length; index++) {
-				const token = structure[index];
-				pushSection(token, token.id.substring(1))
-			}
-		}
-		else if (element.collapsibleState != vscode.TreeItemCollapsibleState.None) {
-			// find sections and scenes within the given element 
-			var elementPath: string[] = element.path.split("/");
-
-			// to recursively find sections and scenes
-			const findSections = (token:afterparser.StructToken, depth:number) => {
-				var tokenPath: string[] = token.id.split("/");
-				if (elementPath.length >= depth+1) {
-					if (tokenPath[depth] == elementPath[depth]) {
-						token.children.forEach((subToken:afterparser.StructToken) => findSections(subToken, depth+1))
-					}
-				}
-				else {
-					pushSection(token, tokenPath[depth]);
-                }
-			}
-
-			structure.forEach(token => findSections(token, 1));
-		}
-
-		elements = elements.sort((a,b)=>a.command.arguments[0]-b.command.arguments[0])
-		this.latestReturnedNodes.push(...elements);
-		return elements;
+		if (element)
+			return element.children;
+		return this.treeRoot.children;
 	}
-	getParent(element: OutlineTreeItem):any{
+	getParent(element: OutlineTreeItem): any {
 		// necessary for reveal() to work
 		return element.parent;
 	}
 	update(): void {
-		this.latestReturnedNodes = [];
+		this.treeRoot = buildTree();
 		this.onDidChangeTreeDataEmitter.fire(void 0);
 	}
 	reveal(): void {
 		const currentCursorLine = getEditor(activeFountainDocument()).selection.active.line;
 
 		// find the closest node without going past the current cursor
-		const closestNode = this.latestReturnedNodes
+		const closestNode = this.treeRoot
 			.filter(node => node.lineNumber <= currentCursorLine)
-			.sort((a,b) => b.lineNumber - a.lineNumber)
-			[0];
+			.sort((a, b) => b.lineNumber - a.lineNumber)[0];
 
 		if (closestNode) {
-			this.treeView.reveal(closestNode, {select: true, focus: false, expand: 3 });
+			this.treeView.reveal(closestNode, { select: true, focus: false, expand: 3 });
 		}
 	}
 }
 
-class OutlineTreeItem extends vscode.TreeItem
-{
-	constructor(label:string, public path:string, public lineNumber:number, public parent:OutlineTreeItem){
+function buildTree(): OutlineTreeItem {
+	const structure = activeParsedDocument().properties.structure;
+	const root = new OutlineTreeItem("", "", null);
+	root.children = structure.map(token => makeTreeItem(token, root));
+	return root;
+}
+
+function makeTreeItem(token: afterparser.StructToken, parent: OutlineTreeItem): OutlineTreeItem {
+	var item: OutlineTreeItem;
+	if (token.section)
+		item = new SectionTreeItem(token, parent);
+	else
+		item = new SceneTreeItem(token, parent);
+
+	item.children = [];
+
+	if (token.children)
+		item.children.push(...token.children.map((tok: afterparser.StructToken) => makeTreeItem(tok, item)));
+
+	if (token.notes && config.uiPersistence.outline_visibleNotes)
+		parent.children.push(...token.notes.map(note => new NoteTreeItem(note, parent)));
+
+	if (token.synopses && config.uiPersistence.outline_visibleSynopses)
+		parent.children.push(...token.synopses.map(syn => new SynopsisTreeItem(syn, parent)));
+
+	if (item.children.length > 0)
+		item.collapsibleState = vscode.TreeItemCollapsibleState.Expanded;
+
+	item.children = item.children.sort((a, b) => a.lineNumber - b.lineNumber);
+	return item;
+}
+
+class OutlineTreeItem extends vscode.TreeItem {
+	children: OutlineTreeItem[];
+	lineNumber: number;
+
+	constructor(label: string, public path: string, public parent: OutlineTreeItem) {
 		super(label);
+
+		if (path) {
+			var endDigits = path.match(/(\d+)$/);
+			if (endDigits && endDigits.length > 1) {
+				this.lineNumber = +endDigits[1];
+				this.command = {
+					command: 'fountain.jumpto',
+					title: '',
+					arguments: [this.lineNumber]
+				};
+			}
+		}
+	}
+
+	/** returns all nodes in the tree that pass this predicate, including this node */
+	filter(predicate: (node: OutlineTreeItem) => boolean): OutlineTreeItem[] {
+		const result: OutlineTreeItem[] = [];
+		if (predicate(this))
+			result.push(this);
+
+		if (this.children)
+			this.children.forEach(child => result.push(...child.filter(predicate)));
+
+		return result;
+	}
+}
+
+class SectionTreeItem extends OutlineTreeItem {
+	constructor(token: afterparser.StructToken, parent: OutlineTreeItem) {
+		super(token.text, token.id, parent)
+
+		var sectionDepth = Math.min((token.id.match(/\//g) || []).length, 5); //maximum depth is 5 - anything deeper is the same color as 5
+		this.iconPath = __filename + '/../../../assets/section' + sectionDepth + '.svg';
+		if (token.synopses && token.synopses.length > 0) {
+			this.tooltip = token.synopses.map(s => s.synopsis).join('\n');
+		}
+	}
+}
+
+class SceneTreeItem extends OutlineTreeItem {
+	constructor(token: afterparser.StructToken, parent: OutlineTreeItem) {
+		super(token.text, token.id, parent)
+
+		this.iconPath = __filename + '/../../../assets/scene.svg';
+		if (token.synopses && token.synopses.length > 0) {
+			this.tooltip = token.synopses.map(s => s.synopsis).join('\n');
+		}
+	}
+}
+
+class NoteTreeItem extends OutlineTreeItem {
+	constructor(token: { note: string, line: number }, parent: OutlineTreeItem) {
+		super("", token.line.toString(), parent)
+
+		this.iconPath = {
+			light: __filename + '/../../../assets/note_light_offset.svg',
+			dark: __filename + '/../../../assets/note_dark_offset.svg'
+		};
+		this.description = token.note;
+		this.tooltip = this.description;
+	}
+}
+
+class SynopsisTreeItem extends OutlineTreeItem {
+	constructor(token: { synopsis: string, line: number }, parent: OutlineTreeItem) {
+		super("", "/" + token.line, parent)
+
+		this.iconPath = __filename + '/../../../assets/synopse_offset.svg';
+		this.description = token.synopsis;
+		this.tooltip = this.description;
 	}
 }


### PR DESCRIPTION
Hi @piersdeseilligny 

TipiT wasn't happy with the first cut.

I'm certain the problem involves FountainOutlineTreeDataProvider.update() being called twice in quick succession (eg. on Save, as is TipiTs main concern) and vscode's following calls to getChildren().

I've updated update() so that it builds the whole model of the tree immediately and getChildren() only has to serve the results. I did this to make update(), getChildren(), and reveal() less dependent on the behaviour of vscode's emitters. It seems to have worked.

Which means I now can't replicate it at all. However TipiT's and my experiences were very different...