### PR TITLE
character names cannot start with ! or #

### DIFF
--- a/src/afterwriting-parser.ts
+++ b/src/afterwriting-parser.ts
@@ -22,7 +22,7 @@ export const regex: { [index: string]: RegExp } = {
 
     dialogue: /^[ \t]*([*_]+[^\p{Ll}\p{Lo}\p{So}\r\n]*)(\^?)?(?:\n(?!\n+))([\s\S]+)/u,
 
-    character: /^[ \t]*(((?!@)[^\p{Ll}\r\n]*?\p{Lu}[^\p{Ll}\r\n]*?)|((@)[^\r\n]*?))(\(.*\))?(\s*\^)?$/u,
+    character: /^[ \t]*(?![#!])(((?!@)[^\p{Ll}\r\n]*?\p{Lu}[^\p{Ll}\r\n]*?)|((@)[^\r\n]*?))(\(.*\))?(\s*\^)?$/u,
     parenthetical: /^[ \t]*(\(.+\))$/,
 
     action: /^(.+)/g,

--- a/syntaxes/fountain.tmlanguage
+++ b/syntaxes/fountain.tmlanguage
@@ -168,7 +168,7 @@
          <key>contentName</key>
          <string>string</string>
          <key>begin</key>
-         <string>^[ \t]*(((?!@)[^\p{Ll}\r\n]*?\p{Lu}[^\p{Ll}\r\n]*?)|((@)[^\r\n]*?))(\(.*\))?(\s*\^)?$</string>
+         <string>^[ \t]*(?![#!])(((?!@)[^\p{Ll}\r\n]*?\p{Lu}[^\p{Ll}\r\n]*?)|((@)[^\r\n]*?))(\(.*\))?(\s*\^)?$</string>
          <key>end</key>
          <string>^$</string>
          <key>beginCaptures</key>


### PR DESCRIPTION
This was only affecting the syntax highlighting colours. The tokenisation seemed to be fine.

Noticeable on Big Fish; lines like 
`THE BEAST.`
were getting coloured as character names.