### PR TITLE
Shift Scenes

### DIFF
--- a/package.json
+++ b/package.json
@@ -342,6 +342,16 @@
 				"command": "fountain.debugtokens",
 				"title": "Debug parsed output",
 				"category": "Fountain"
+			},
+			{
+				"command": "fountain.shiftScenesUp",
+				"title": "Shift Scenes Up",
+				"category": "Fountain"
+			},
+			{
+				"command": "fountain.shiftScenesDown",
+				"title": "Shift Scenes Down",
+				"category": "Fountain"
 			}
 		],
 		"keybindings": [
@@ -361,6 +371,18 @@
 				"command": "fountain.exportpdfdebug",
 				"key": "f5",
 				"mac": "f5",
+				"when": "editorLangId == fountain"
+			},
+			{
+				"command": "fountain.shiftScenesUp",
+				"key": "alt+up",
+				"mac": "alt+up",
+				"when": "editorLangId == fountain"
+			},
+			{
+				"command": "fountain.shiftScenesDown",
+				"key": "alt+down",
+				"mac": "alt+down",
 				"when": "editorLangId == fountain"
 			}
 		],

--- a/src/afterwriting-parser.ts
+++ b/src/afterwriting-parser.ts
@@ -209,11 +209,11 @@ export var parse = function (original_script: string, cfg: any, generate_html: b
 
     const latestSectionOrScene = (depth: number, condition: (token: StructToken) => boolean): StructToken => {
         try {
-            if (depth == 0) {
+            if (depth <= 0) {
                 return null;
             }
             else if (depth == 1) {
-                return last(result.properties.structure)
+                return last(result.properties.structure.filter(condition))
             }
             else {
                 var prevSection = latestSectionOrScene(depth - 1, condition)
@@ -227,7 +227,7 @@ export var parse = function (original_script: string, cfg: any, generate_html: b
         }
         catch {
             var section: StructToken = null;
-            while (!section) section = latestSectionOrScene(--depth, condition);
+            while (!section && depth > 0) section = latestSectionOrScene(--depth, condition);
             return section;
         }
     }
@@ -396,12 +396,12 @@ export var parse = function (original_script: string, cfg: any, generate_html: b
                 cobj.range = new Range(new Position(thistoken.line, 0), new Position(thistoken.line, thistoken.text.length));
                 cobj.section = true;
 
-                if (current_depth == 1) {
+                const level = current_depth > 1 && latestSection(current_depth - 1);
+                if (current_depth == 1 || !level) {
                     cobj.id = '/' + thistoken.line;
                     result.properties.structure.push(cobj)
                 }
                 else {
-                    var level = latestSection(current_depth - 1);
                     cobj.id = level.id + '/' + thistoken.line;
                     level.children.push(cobj);
                 }

--- a/src/afterwriting-parser.ts
+++ b/src/afterwriting-parser.ts
@@ -112,6 +112,7 @@ export interface parseoutput {
     tokenLines: { [line: number]: number }
     lengthAction: number,
     lengthDialogue: number,
+    parseTime: number,
     properties: screenplayProperties
 }
 export var parse = function (original_script: string, cfg: any, generate_html: boolean): parseoutput {
@@ -126,6 +127,7 @@ export var parse = function (original_script: string, cfg: any, generate_html: b
             lengthAction: 0,
             lengthDialogue: 0,
             tokenLines: {},
+            parseTime: +new Date(),
             properties:
             {
                 sceneLines: [],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -197,6 +197,88 @@ const writeSceneNumbers = (fullText: string) => {
 	}
 }
 
+/** Shifts scene/s at the selected text up or down */
+export const shiftScenes = (editor: vscode.TextEditor, parsed: parser.parseoutput, direction: number) => {
+
+	var numNewlinesAtEndRequired = 0;
+	const selectSceneAt = (sel: vscode.Selection): vscode.Selection => {
+		// returns range that contains whole scenes that overlap with the selection
+		const headingsBefore = parsed.tokens
+			.filter(token => (token.is("scene_heading") || token.is("section"))
+				&& token.line <= sel.active.line
+				&& token.line <= sel.anchor.line)
+			.sort((a, b) => b.line - a.line);
+		const headingsAfter = parsed.tokens
+			.filter(token => (token.is("scene_heading") || token.is("section"))
+				&& token.line > sel.active.line
+				&& token.line > sel.anchor.line)
+			.sort((a, b) => a.line - b.line);
+
+		if (headingsBefore.length == 0) return null;
+		const selStart = +headingsBefore[0].line;
+
+		if (headingsAfter.length) {
+			const selEnd = +headingsAfter[0].line;
+			return new vscode.Selection(selStart, 0, selEnd, 0);
+		}
+		else {
+			// +2 is where the next scene would start if there was one. done to make it look consistent.
+			const selEnd = last(parsed.tokens).line + 2;
+			if (selEnd >= editor.document.lineCount) numNewlinesAtEndRequired = selEnd - editor.document.lineCount + 1;
+			return new vscode.Selection(selStart, 0, selEnd, 0);
+		}
+	}
+
+	// get range of scene/s that are shifting
+	var moveSelection = selectSceneAt(editor.selection);
+	if (moveSelection == null) return; // edge case: using command before the first scene
+	var moveText = editor.document.getText(moveSelection) + (new Array(numNewlinesAtEndRequired + 1).join("\n"));
+	numNewlinesAtEndRequired = 0;
+
+	// get range of scene being swapped with selected scene/s
+	var aboveSelection = (direction == -1) && selectSceneAt(new vscode.Selection(moveSelection.anchor.line - 1, 0, moveSelection.anchor.line - 1, 0));
+	var belowSelection = (direction == 1) && selectSceneAt(new vscode.Selection(moveSelection.active.line + 1, 0, moveSelection.active.line + 1, 0));
+
+	// edge cases: no scenes above or below to swap with
+	if (!belowSelection && !aboveSelection) return;
+	if (belowSelection && belowSelection.anchor.line < moveSelection.active.line) return;
+
+	var reselectDelta = 0;
+	const newLinePos = editor.document.lineAt(editor.document.lineCount - 1).range.end;
+
+	editor.edit(editBuilder => {
+		// going bottom-up to avoid re-aligning line numbers
+
+		// might need empty lines at the bottom so the cut-paste behaves the same as if there were more scenes
+		while (numNewlinesAtEndRequired) {
+			// vscode makes this \r\n when appropriate
+			editBuilder.insert(newLinePos, "\n");
+			numNewlinesAtEndRequired--;
+		}
+
+		// paste below?
+		if (belowSelection) {
+			editBuilder.insert(new vscode.Position(belowSelection.active.line, 0), moveText);
+			reselectDelta = belowSelection.active.line - belowSelection.anchor.line;
+		}
+
+		// delete original
+		editBuilder.delete(moveSelection)
+
+		// paste above?
+		if (aboveSelection) {
+			editBuilder.insert(new vscode.Position(aboveSelection.anchor.line, 0), moveText);
+			reselectDelta = aboveSelection.anchor.line - moveSelection.anchor.line;
+		}
+	});
+
+	// reselect any text that was originally selected / cursor position
+	editor.selection = new vscode.Selection(
+		editor.selection.anchor.translate(reselectDelta),
+		editor.selection.active.translate(reselectDelta));
+	editor.revealRange(editor.selection);
+};
+
 export const last = function (array: any[]): any {
 	return array[array.length - 1];
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -223,7 +223,7 @@ export const shiftScenes = (editor: vscode.TextEditor, parsed: parser.parseoutpu
 		}
 		else {
 			// +2 is where the next scene would start if there was one. done to make it look consistent.
-			const selEnd = last(parsed.tokens).line + 2;
+			const selEnd = last(parsed.tokens.filter(token => token.line)).line + 2;
 			if (selEnd >= editor.document.lineCount) numNewlinesAtEndRequired = selEnd - editor.document.lineCount + 1;
 			return new vscode.Selection(selStart, 0, selEnd, 0);
 		}


### PR DESCRIPTION
**Inspiration**
Inspired by #80, and the "shift line up/down" command (which in vscode is mapped to alt+up, alt+down).

I've mapped it to the same keys (alt+up, alt+down) to make it easier to remember and I suspect the original shift-line command is a lot less useful for fountain than for programming so no one will mind it being overridden.

**Usage**
Shifts the scene/section where the cursor is, or (just like the original shift-line command) if you have selected text that spans multiple scenes, they will all shift as one block.

**Bugfix Included**
While testing I shifted sections such that I got this:
```
### deep section before
# shallow section
```
which broke the parser. It's only a problem if the first section in the document is bad like this. After the fix, the outline looks the same as if the document had read:
```
# deep section before
# shallow section
```