### PR TITLE
Add missing settings for scene continuation

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,6 +264,21 @@
 						"type": "string",
 						"default": "(CONT'D)",
 						"description": "Text to print by a character's name when continuing dialogue after a page break - \"(CONT'D)\" in English."
+					},
+					"fountain.pdf.textSceneContinued": {
+						"type": "string",
+						"default": "",
+						"description": "Text to print when scene is cut before a page break - \"(CONINUED)\" in English."
+					},
+					"fountain.pdf.sceneContinuationTop": {
+						"type": "boolean",
+						"default": true,
+						"description": "Display CONTINUED on top of pages when scene is cut before a page break"
+					},
+					"fountain.pdf.sceneContinuationBottom": {
+						"type": "boolean",
+						"default": true,
+						"description": "Display CONTINUED on bottom of pages when scene is cut before a page break"
 					}
 				}
 			}

--- a/package.json
+++ b/package.json
@@ -267,19 +267,20 @@
 					},
 					"fountain.pdf.textSceneContinued": {
 						"type": "string",
-						"default": "",
-						"description": "Text to print when scene is cut before a page break - \"(CONINUED)\" in English."
+						"default": "CONTINUED",
+						"markdownDescription": "Text to print if `#fountain.pdf.sceneContinuationTop#` or `#fountain.pdf.sceneContinuationBottom#` are enabled - `CONTINUED` in English."
 					},
 					"fountain.pdf.sceneContinuationTop": {
 						"type": "boolean",
-						"default": true,
-						"description": "Display CONTINUED on top of pages when scene is cut before a page break"
+						"default": false,
+						"markdownDescription": "Display `CONTINUED:` at the top of pages where a scene is split by a page break. If `#fountain.pdf.sceneNumbers#` is enabled, the scene number will be included (eg `12A CONTINUED:)`"
 					},
 					"fountain.pdf.sceneContinuationBottom": {
 						"type": "boolean",
-						"default": true,
-						"description": "Display CONTINUED on bottom of pages when scene is cut before a page break"
+						"default": false,
+						"markdownDescription": "Display `(CONTINUED)` at the bottom of pages where a scene is cut by a page break."
 					}
+
 				}
 			}
 		],

--- a/src/configloader.ts
+++ b/src/configloader.ts
@@ -128,7 +128,7 @@ export var getFountainConfig = function(docuri:vscode.Uri):FountainConfig{
         invisible_section_bookmarks: pdfConfig.invisibleSectionBookmarks,
         text_more: pdfConfig.textMORE,
         text_contd: pdfConfig.textCONTD,
-        text_scene_continuation: pdfConfig.textSceneContinuation,
+        text_scene_continuation: pdfConfig.textSceneContinued,
         scene_continuation_top: pdfConfig.sceneContinuationTop,
         scene_continuation_bottom: pdfConfig.sceneContinuationBottom,
         synchronized_markup_and_preview: generalConfig.synchronizedMarkupAndPreview,

--- a/src/configloader.ts
+++ b/src/configloader.ts
@@ -33,6 +33,9 @@ export class FountainConfig{
     preview_texture:boolean;
     text_more:string;
     text_contd:string;
+    text_scene_continuation:string;
+    scene_continuation_top:boolean;
+    scene_continuation_bottom:boolean;
     parenthetical_newline_helper:boolean;
 }
 
@@ -125,6 +128,9 @@ export var getFountainConfig = function(docuri:vscode.Uri):FountainConfig{
         invisible_section_bookmarks: pdfConfig.invisibleSectionBookmarks,
         text_more: pdfConfig.textMORE,
         text_contd: pdfConfig.textCONTD,
+        text_scene_continuation: pdfConfig.textSceneContinuation,
+        scene_continuation_top: pdfConfig.sceneContinuationTop,
+        scene_continuation_bottom: pdfConfig.sceneContinuationBottom,
         synchronized_markup_and_preview: generalConfig.synchronizedMarkupAndPreview,
         preview_theme: generalConfig.previewTheme,
         preview_texture: generalConfig.previewTexture,


### PR DESCRIPTION
Hi ! First of all thanks for this very useful extension.

I was looking for the _CONTINUED_ feature when a scene is cut before a page break but I wasn't able to find the setting.
I looked deeply into the code and found that the feature exists but only the settings part was missing.

This pull request consists of 3 new settings :
- sceneContinuationTop : To enable the display of CONTINUED at the top of pages
- sceneContinuationBottom : To enable the display of CONTINUED at the bottom of pages
- textSceneContinued : Text to print instead of CONTINUED

