### PR TITLE
add cheatsheet to extension sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,11 @@
 {
 	"name": "betterfountain",
-	"version": "1.9.2",
+	"version": "1.10.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "betterfountain",
-			"version": "1.9.2",
+			"version": "1.10.0",
 			"license": "MIT",
 			"dependencies": {
 				"blob": "0.1.0",
@@ -1501,7 +1500,8 @@
 			"dependencies": {
 				"esprima": "~1.0.4",
 				"estraverse": "~1.5.0",
-				"esutils": "~1.0.0"
+				"esutils": "~1.0.0",
+				"source-map": "~0.1.30"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",
@@ -2364,6 +2364,7 @@
 			"dependencies": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
+				"fsevents": "~2.3.2",
 				"glob-parent": "~5.1.2",
 				"is-binary-path": "~2.1.0",
 				"is-glob": "~4.0.1",
@@ -4252,7 +4253,8 @@
 				"esprima": "^3.1.3",
 				"estraverse": "^4.2.0",
 				"esutils": "^2.0.2",
-				"optionator": "^0.8.1"
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",
@@ -4623,6 +4625,7 @@
 			"integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
 			"dev": true,
 			"dependencies": {
+				"@types/yauzl": "^2.9.1",
 				"debug": "^4.1.1",
 				"get-stream": "^5.1.0",
 				"yauzl": "^2.10.0"
@@ -4920,7 +4923,71 @@
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
 			"integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
 			"bundleDependencies": [
-				"node-pre-gyp"
+				"node-pre-gyp",
+				"abbrev",
+				"ansi-regex",
+				"aproba",
+				"are-we-there-yet",
+				"balanced-match",
+				"brace-expansion",
+				"chownr",
+				"code-point-at",
+				"concat-map",
+				"console-control-strings",
+				"core-util-is",
+				"debug",
+				"deep-extend",
+				"delegates",
+				"detect-libc",
+				"fs-minipass",
+				"fs.realpath",
+				"gauge",
+				"glob",
+				"has-unicode",
+				"iconv-lite",
+				"ignore-walk",
+				"inflight",
+				"inherits",
+				"ini",
+				"is-fullwidth-code-point",
+				"isarray",
+				"minimatch",
+				"minimist",
+				"minipass",
+				"minizlib",
+				"mkdirp",
+				"ms",
+				"needle",
+				"nopt",
+				"npm-bundled",
+				"npm-packlist",
+				"npmlog",
+				"number-is-nan",
+				"object-assign",
+				"once",
+				"os-homedir",
+				"os-tmpdir",
+				"osenv",
+				"path-is-absolute",
+				"process-nextick-args",
+				"rc",
+				"readable-stream",
+				"rimraf",
+				"safe-buffer",
+				"safer-buffer",
+				"sax",
+				"semver",
+				"set-blocking",
+				"signal-exit",
+				"string_decoder",
+				"string-width",
+				"strip-ansi",
+				"strip-json-comments",
+				"tar",
+				"util-deprecate",
+				"wide-align",
+				"wrappy",
+				"yallist"
 			],
 			"deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
 			"dev": true,
@@ -4939,16 +5006,20 @@
 		},
 		"node_modules/fsevents/node_modules/abbrev": {
 			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/ansi-regex": {
 			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -4956,16 +5027,20 @@
 		},
 		"node_modules/fsevents/node_modules/aproba": {
 			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/are-we-there-yet": {
 			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"delegates": "^1.0.0",
@@ -4974,16 +5049,20 @@
 		},
 		"node_modules/fsevents/node_modules/balanced-match": {
 			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 			"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/brace-expansion": {
 			"version": "1.1.11",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -4992,16 +5071,20 @@
 		},
 		"node_modules/fsevents/node_modules/chownr": {
 			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
 			"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/code-point-at": {
 			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -5009,31 +5092,38 @@
 		},
 		"node_modules/fsevents/node_modules/concat-map": {
 			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/console-control-strings": {
 			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/core-util-is": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/debug": {
 			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-			"deprecated": "Debug versions >=3.2.0 <3.2.7 || >=4 <4.3.1 have a low-severity ReDos regression when used in a Node.js environment. It is recommended you upgrade to 3.2.7 or 4.3.1. (https://github.com/visionmedia/debug/issues/797)",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"ms": "^2.1.1"
@@ -5041,9 +5131,11 @@
 		},
 		"node_modules/fsevents/node_modules/deep-extend": {
 			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">=4.0.0"
@@ -5051,16 +5143,20 @@
 		},
 		"node_modules/fsevents/node_modules/delegates": {
 			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/detect-libc": {
 			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 			"dev": true,
 			"inBundle": true,
+			"license": "Apache-2.0",
 			"optional": true,
 			"bin": {
 				"detect-libc": "bin/detect-libc.js"
@@ -5071,9 +5167,11 @@
 		},
 		"node_modules/fsevents/node_modules/fs-minipass": {
 			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
 			"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"minipass": "^2.2.1"
@@ -5081,16 +5179,20 @@
 		},
 		"node_modules/fsevents/node_modules/fs.realpath": {
 			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/gauge": {
 			"version": "2.7.4",
+			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"aproba": "^1.0.3",
@@ -5105,9 +5207,11 @@
 		},
 		"node_modules/fsevents/node_modules/glob": {
 			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 			"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
@@ -5123,16 +5227,20 @@
 		},
 		"node_modules/fsevents/node_modules/has-unicode": {
 			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/iconv-lite": {
 			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"safer-buffer": ">= 2.1.2 < 3"
@@ -5143,9 +5251,11 @@
 		},
 		"node_modules/fsevents/node_modules/ignore-walk": {
 			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
 			"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"minimatch": "^3.0.4"
@@ -5153,9 +5263,11 @@
 		},
 		"node_modules/fsevents/node_modules/inflight": {
 			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"once": "^1.3.0",
@@ -5164,17 +5276,20 @@
 		},
 		"node_modules/fsevents/node_modules/inherits": {
 			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 			"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/ini": {
 			"version": "1.3.5",
+			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
 			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"deprecated": "Please update to ini >=1.3.6 to avoid a prototype pollution issue",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"engines": {
 				"node": "*"
@@ -5182,9 +5297,11 @@
 		},
 		"node_modules/fsevents/node_modules/is-fullwidth-code-point": {
 			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"number-is-nan": "^1.0.0"
@@ -5195,16 +5312,20 @@
 		},
 		"node_modules/fsevents/node_modules/isarray": {
 			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/minimatch": {
 			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 			"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
@@ -5215,16 +5336,20 @@
 		},
 		"node_modules/fsevents/node_modules/minimist": {
 			"version": "0.0.8",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/minipass": {
 			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 			"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"safe-buffer": "^5.1.2",
@@ -5233,9 +5358,11 @@
 		},
 		"node_modules/fsevents/node_modules/minizlib": {
 			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
 			"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"minipass": "^2.2.1"
@@ -5243,10 +5370,11 @@
 		},
 		"node_modules/fsevents/node_modules/mkdirp": {
 			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-			"deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"minimist": "0.0.8"
@@ -5257,16 +5385,20 @@
 		},
 		"node_modules/fsevents/node_modules/ms": {
 			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/needle": {
 			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
 			"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"debug": "^4.1.0",
@@ -5282,10 +5414,11 @@
 		},
 		"node_modules/fsevents/node_modules/node-pre-gyp": {
 			"version": "0.12.0",
+			"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
 			"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
-			"deprecated": "Please upgrade to @mapbox/node-pre-gyp: the non-scoped node-pre-gyp package is deprecated and only the @mapbox scoped package will recieve updates in the future",
 			"dev": true,
 			"inBundle": true,
+			"license": "BSD-3-Clause",
 			"optional": true,
 			"dependencies": {
 				"detect-libc": "^1.0.2",
@@ -5305,9 +5438,11 @@
 		},
 		"node_modules/fsevents/node_modules/nopt": {
 			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 			"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"abbrev": "1",
@@ -5319,16 +5454,20 @@
 		},
 		"node_modules/fsevents/node_modules/npm-bundled": {
 			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
 			"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/npm-packlist": {
 			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
 			"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"ignore-walk": "^3.0.1",
@@ -5337,9 +5476,11 @@
 		},
 		"node_modules/fsevents/node_modules/npmlog": {
 			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"are-we-there-yet": "~1.1.2",
@@ -5350,9 +5491,11 @@
 		},
 		"node_modules/fsevents/node_modules/number-is-nan": {
 			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -5360,9 +5503,11 @@
 		},
 		"node_modules/fsevents/node_modules/object-assign": {
 			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -5370,9 +5515,11 @@
 		},
 		"node_modules/fsevents/node_modules/once": {
 			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"wrappy": "1"
@@ -5380,9 +5527,11 @@
 		},
 		"node_modules/fsevents/node_modules/os-homedir": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -5390,9 +5539,11 @@
 		},
 		"node_modules/fsevents/node_modules/os-tmpdir": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -5400,9 +5551,11 @@
 		},
 		"node_modules/fsevents/node_modules/osenv": {
 			"version": "0.1.5",
+			"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 			"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"os-homedir": "^1.0.0",
@@ -5411,9 +5564,11 @@
 		},
 		"node_modules/fsevents/node_modules/path-is-absolute": {
 			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -5421,16 +5576,20 @@
 		},
 		"node_modules/fsevents/node_modules/process-nextick-args": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 			"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/rc": {
 			"version": "1.2.8",
+			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 			"dev": true,
 			"inBundle": true,
+			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
 			"optional": true,
 			"dependencies": {
 				"deep-extend": "^0.6.0",
@@ -5444,16 +5603,20 @@
 		},
 		"node_modules/fsevents/node_modules/rc/node_modules/minimist": {
 			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/readable-stream": {
 			"version": "2.3.6",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"core-util-is": "~1.0.0",
@@ -5467,9 +5630,11 @@
 		},
 		"node_modules/fsevents/node_modules/rimraf": {
 			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 			"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"glob": "^7.1.3"
@@ -5480,30 +5645,38 @@
 		},
 		"node_modules/fsevents/node_modules/safe-buffer": {
 			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/safer-buffer": {
 			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/sax": {
 			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/semver": {
 			"version": "5.7.0",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
 			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"bin": {
 				"semver": "bin/semver"
@@ -5511,23 +5684,29 @@
 		},
 		"node_modules/fsevents/node_modules/set-blocking": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/signal-exit": {
 			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 			"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/string_decoder": {
 			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
@@ -5535,9 +5714,11 @@
 		},
 		"node_modules/fsevents/node_modules/string-width": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"code-point-at": "^1.0.0",
@@ -5550,9 +5731,11 @@
 		},
 		"node_modules/fsevents/node_modules/strip-ansi": {
 			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"dependencies": {
 				"ansi-regex": "^2.0.0"
@@ -5563,9 +5746,11 @@
 		},
 		"node_modules/fsevents/node_modules/strip-json-comments": {
 			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
@@ -5573,9 +5758,11 @@
 		},
 		"node_modules/fsevents/node_modules/tar": {
 			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
 			"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"chownr": "^1.1.1",
@@ -5592,16 +5779,20 @@
 		},
 		"node_modules/fsevents/node_modules/util-deprecate": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 			"dev": true,
 			"inBundle": true,
+			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/wide-align": {
 			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true,
 			"dependencies": {
 				"string-width": "^1.0.2 || 2"
@@ -5609,16 +5800,20 @@
 		},
 		"node_modules/fsevents/node_modules/wrappy": {
 			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fsevents/node_modules/yallist": {
 			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
 			"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 			"dev": true,
 			"inBundle": true,
+			"license": "ISC",
 			"optional": true
 		},
 		"node_modules/fstream": {
@@ -6971,6 +7166,7 @@
 				"@jest/types": "^24.9.0",
 				"anymatch": "^2.0.0",
 				"fb-watchman": "^2.0.0",
+				"fsevents": "^1.2.7",
 				"graceful-fs": "^4.1.15",
 				"invariant": "^2.2.4",
 				"jest-serializer": "^24.9.0",
@@ -10370,7 +10566,8 @@
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
 				"esutils": "^2.0.2",
-				"optionator": "^0.8.1"
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",
@@ -10437,7 +10634,8 @@
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
 				"esutils": "^2.0.2",
-				"optionator": "^0.8.1"
+				"optionator": "^0.8.1",
+				"source-map": "~0.6.1"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",
@@ -11746,8 +11944,10 @@
 			"integrity": "sha512-9P3MWk6SrKjHsGkLT2KHXdQ/9SNkyoJbabxnKOoJepsvJjJG8uYTR3yTPxPQvNDI3w4Nz1xnE0TLHK4RIVe/MQ==",
 			"dev": true,
 			"dependencies": {
+				"chokidar": "^3.4.1",
 				"graceful-fs": "^4.1.2",
-				"neo-async": "^2.5.0"
+				"neo-async": "^2.5.0",
+				"watchpack-chokidar2": "^2.0.1"
 			},
 			"optionalDependencies": {
 				"chokidar": "^3.4.1",
@@ -11785,6 +11985,7 @@
 				"anymatch": "^2.0.0",
 				"async-each": "^1.0.1",
 				"braces": "^2.3.2",
+				"fsevents": "^1.2.7",
 				"glob-parent": "^3.1.0",
 				"inherits": "^2.0.3",
 				"is-binary-path": "^1.0.0",
@@ -16412,6 +16613,7 @@
 			"dependencies": {
 				"abbrev": {
 					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 					"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
 					"bundled": true,
 					"dev": true,
@@ -16419,6 +16621,7 @@
 				},
 				"ansi-regex": {
 					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
 					"bundled": true,
 					"dev": true,
@@ -16426,6 +16629,7 @@
 				},
 				"aproba": {
 					"version": "1.2.0",
+					"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
 					"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
 					"bundled": true,
 					"dev": true,
@@ -16433,6 +16637,7 @@
 				},
 				"are-we-there-yet": {
 					"version": "1.1.5",
+					"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 					"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
 					"bundled": true,
 					"dev": true,
@@ -16444,6 +16649,7 @@
 				},
 				"balanced-match": {
 					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
 					"bundled": true,
 					"dev": true,
@@ -16451,6 +16657,7 @@
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"bundled": true,
 					"dev": true,
@@ -16462,6 +16669,7 @@
 				},
 				"chownr": {
 					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
 					"integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
 					"bundled": true,
 					"dev": true,
@@ -16469,6 +16677,7 @@
 				},
 				"code-point-at": {
 					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
 					"bundled": true,
 					"dev": true,
@@ -16476,6 +16685,7 @@
 				},
 				"concat-map": {
 					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 					"bundled": true,
 					"dev": true,
@@ -16483,6 +16693,7 @@
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
 					"bundled": true,
 					"dev": true,
@@ -16490,6 +16701,7 @@
 				},
 				"core-util-is": {
 					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
 					"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
 					"bundled": true,
 					"dev": true,
@@ -16497,6 +16709,7 @@
 				},
 				"debug": {
 					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
 					"bundled": true,
 					"dev": true,
@@ -16507,6 +16720,7 @@
 				},
 				"deep-extend": {
 					"version": "0.6.0",
+					"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 					"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
 					"bundled": true,
 					"dev": true,
@@ -16514,6 +16728,7 @@
 				},
 				"delegates": {
 					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
 					"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
 					"bundled": true,
 					"dev": true,
@@ -16521,6 +16736,7 @@
 				},
 				"detect-libc": {
 					"version": "1.0.3",
+					"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
 					"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
 					"bundled": true,
 					"dev": true,
@@ -16528,6 +16744,7 @@
 				},
 				"fs-minipass": {
 					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
 					"integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
 					"bundled": true,
 					"dev": true,
@@ -16538,6 +16755,7 @@
 				},
 				"fs.realpath": {
 					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 					"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 					"bundled": true,
 					"dev": true,
@@ -16545,6 +16763,7 @@
 				},
 				"gauge": {
 					"version": "2.7.4",
+					"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 					"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
 					"bundled": true,
 					"dev": true,
@@ -16562,6 +16781,7 @@
 				},
 				"glob": {
 					"version": "7.1.3",
+					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
 					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
 					"bundled": true,
 					"dev": true,
@@ -16577,6 +16797,7 @@
 				},
 				"has-unicode": {
 					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
 					"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
 					"bundled": true,
 					"dev": true,
@@ -16584,6 +16805,7 @@
 				},
 				"iconv-lite": {
 					"version": "0.4.24",
+					"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
 					"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
 					"bundled": true,
 					"dev": true,
@@ -16594,6 +16816,7 @@
 				},
 				"ignore-walk": {
 					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
 					"integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
 					"bundled": true,
 					"dev": true,
@@ -16604,6 +16827,7 @@
 				},
 				"inflight": {
 					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 					"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 					"bundled": true,
 					"dev": true,
@@ -16615,6 +16839,7 @@
 				},
 				"inherits": {
 					"version": "2.0.3",
+					"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
 					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
 					"bundled": true,
 					"dev": true,
@@ -16622,6 +16847,7 @@
 				},
 				"ini": {
 					"version": "1.3.5",
+					"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
 					"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
 					"bundled": true,
 					"dev": true,
@@ -16629,6 +16855,7 @@
 				},
 				"is-fullwidth-code-point": {
 					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"bundled": true,
 					"dev": true,
@@ -16639,6 +16866,7 @@
 				},
 				"isarray": {
 					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
 					"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
 					"bundled": true,
 					"dev": true,
@@ -16646,6 +16874,7 @@
 				},
 				"minimatch": {
 					"version": "3.0.4",
+					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"bundled": true,
 					"dev": true,
@@ -16656,6 +16885,7 @@
 				},
 				"minimist": {
 					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
 					"bundled": true,
 					"dev": true,
@@ -16663,6 +16893,7 @@
 				},
 				"minipass": {
 					"version": "2.3.5",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
 					"integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
 					"bundled": true,
 					"dev": true,
@@ -16674,6 +16905,7 @@
 				},
 				"minizlib": {
 					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
 					"integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
 					"bundled": true,
 					"dev": true,
@@ -16684,6 +16916,7 @@
 				},
 				"mkdirp": {
 					"version": "0.5.1",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"bundled": true,
 					"dev": true,
@@ -16694,6 +16927,7 @@
 				},
 				"ms": {
 					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 					"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 					"bundled": true,
 					"dev": true,
@@ -16701,6 +16935,7 @@
 				},
 				"needle": {
 					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
 					"integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
 					"bundled": true,
 					"dev": true,
@@ -16713,6 +16948,7 @@
 				},
 				"node-pre-gyp": {
 					"version": "0.12.0",
+					"resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
 					"integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
 					"bundled": true,
 					"dev": true,
@@ -16732,6 +16968,7 @@
 				},
 				"nopt": {
 					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
 					"integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
 					"bundled": true,
 					"dev": true,
@@ -16743,6 +16980,7 @@
 				},
 				"npm-bundled": {
 					"version": "1.0.6",
+					"resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
 					"integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
 					"bundled": true,
 					"dev": true,
@@ -16750,6 +16988,7 @@
 				},
 				"npm-packlist": {
 					"version": "1.4.1",
+					"resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
 					"integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
 					"bundled": true,
 					"dev": true,
@@ -16761,6 +17000,7 @@
 				},
 				"npmlog": {
 					"version": "4.1.2",
+					"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 					"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
 					"bundled": true,
 					"dev": true,
@@ -16774,6 +17014,7 @@
 				},
 				"number-is-nan": {
 					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 					"bundled": true,
 					"dev": true,
@@ -16781,6 +17022,7 @@
 				},
 				"object-assign": {
 					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 					"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
 					"bundled": true,
 					"dev": true,
@@ -16788,6 +17030,7 @@
 				},
 				"once": {
 					"version": "1.4.0",
+					"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"bundled": true,
 					"dev": true,
@@ -16798,6 +17041,7 @@
 				},
 				"os-homedir": {
 					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
 					"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
 					"bundled": true,
 					"dev": true,
@@ -16805,6 +17049,7 @@
 				},
 				"os-tmpdir": {
 					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
 					"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
 					"bundled": true,
 					"dev": true,
@@ -16812,6 +17057,7 @@
 				},
 				"osenv": {
 					"version": "0.1.5",
+					"resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
 					"integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
 					"bundled": true,
 					"dev": true,
@@ -16823,6 +17069,7 @@
 				},
 				"path-is-absolute": {
 					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 					"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 					"bundled": true,
 					"dev": true,
@@ -16830,6 +17077,7 @@
 				},
 				"process-nextick-args": {
 					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
 					"integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
 					"bundled": true,
 					"dev": true,
@@ -16837,6 +17085,7 @@
 				},
 				"rc": {
 					"version": "1.2.8",
+					"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 					"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
 					"bundled": true,
 					"dev": true,
@@ -16850,6 +17099,7 @@
 					"dependencies": {
 						"minimist": {
 							"version": "1.2.0",
+							"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
 							"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
 							"bundled": true,
 							"dev": true,
@@ -16859,6 +17109,7 @@
 				},
 				"readable-stream": {
 					"version": "2.3.6",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
 					"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
 					"bundled": true,
 					"dev": true,
@@ -16875,6 +17126,7 @@
 				},
 				"rimraf": {
 					"version": "2.6.3",
+					"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
 					"integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
 					"bundled": true,
 					"dev": true,
@@ -16885,6 +17137,7 @@
 				},
 				"safe-buffer": {
 					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
 					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
 					"bundled": true,
 					"dev": true,
@@ -16892,6 +17145,7 @@
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
 					"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 					"bundled": true,
 					"dev": true,
@@ -16899,6 +17153,7 @@
 				},
 				"sax": {
 					"version": "1.2.4",
+					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
 					"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
 					"bundled": true,
 					"dev": true,
@@ -16906,6 +17161,7 @@
 				},
 				"semver": {
 					"version": "5.7.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
 					"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
 					"bundled": true,
 					"dev": true,
@@ -16913,6 +17169,7 @@
 				},
 				"set-blocking": {
 					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
 					"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
 					"bundled": true,
 					"dev": true,
@@ -16920,6 +17177,7 @@
 				},
 				"signal-exit": {
 					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
 					"integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
 					"bundled": true,
 					"dev": true,
@@ -16927,6 +17185,7 @@
 				},
 				"string_decoder": {
 					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 					"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
 					"bundled": true,
 					"dev": true,
@@ -16937,6 +17196,7 @@
 				},
 				"string-width": {
 					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"bundled": true,
 					"dev": true,
@@ -16949,6 +17209,7 @@
 				},
 				"strip-ansi": {
 					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"bundled": true,
 					"dev": true,
@@ -16959,6 +17220,7 @@
 				},
 				"strip-json-comments": {
 					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 					"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
 					"bundled": true,
 					"dev": true,
@@ -16966,6 +17228,7 @@
 				},
 				"tar": {
 					"version": "4.4.8",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
 					"integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
 					"bundled": true,
 					"dev": true,
@@ -16982,6 +17245,7 @@
 				},
 				"util-deprecate": {
 					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 					"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
 					"bundled": true,
 					"dev": true,
@@ -16989,6 +17253,7 @@
 				},
 				"wide-align": {
 					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 					"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
 					"bundled": true,
 					"dev": true,
@@ -16999,6 +17264,7 @@
 				},
 				"wrappy": {
 					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 					"bundled": true,
 					"dev": true,
@@ -17006,6 +17272,7 @@
 				},
 				"yallist": {
 					"version": "3.0.3",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
 					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
 					"bundled": true,
 					"dev": true,

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
 				},
 				{
 					"id": "fountain-cheatsheet",
-					"name": "Cheat Sheet"
+					"name": "Cheat Sheet",
+					"type": "webview"
 				}
 			]
 		},
@@ -424,7 +425,7 @@
 	},
 	"scripts": {
 		"vscode:prepublish": "npm run compile",
-		"compilewebviews": "copyfiles -u 2 webviews/src/*.html webviews/out && webpack --config './webviews/stats.webpack.config.js'",
+		"compilewebviews": "copyfiles -u 2 webviews/src/*.html webviews/src/cheatsheet.css webviews/out && webpack --config './webviews/stats.webpack.config.js'",
 		"compile": "tsc -p ./ && npm run compilewebviews && copyfiles -u 2 webviews/out/* out/webviews && copyfiles -u 1 src/courierprime/*.ttf out && copyfiles -u 1 src/noisetexture.png out",
 		"watch": "npm run compile",
 		"test": "node node_modules/jest/bin/jest.js",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,10 @@
 				{
 					"id": "fountain-commands",
 					"name": "Commands"
+				},
+				{
+					"id": "fountain-cheatsheet",
+					"name": "Cheat Sheet"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 		"onCommand:fountain:exporthtml",
 		"onCommand:fountain.exportpdfdebug",
 		"onCommand:fountain.exportpdfcustom",
+		"onView:fountain-cheatsheet",
 		"onWebviewPanel:fountainPreview"
 	],
 	"main": "./out/extension",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,7 +125,6 @@ function updateStatus(lengthAction: number, lengthDialogue: number): void {
 var durationStatus: vscode.StatusBarItem;
 const outlineViewProvider: FountainOutlineTreeDataProvider = new FountainOutlineTreeDataProvider();
 const commandViewProvider: FountainCommandTreeDataProvider = new FountainCommandTreeDataProvider();
-const cheatsheetViewProvider: FountainCheatSheetWebviewViewProvider = new FountainCheatSheetWebviewViewProvider();
 var lastShiftedParseId = "";
 
 export let diagnosticCollection = languages.createDiagnosticCollection("fountain");
@@ -221,6 +220,7 @@ export function activate(context: ExtensionContext) {
 	vscode.window.createTreeView("fountain-commands", { treeDataProvider: commandViewProvider });
 
 	//Register cheatsheet web view
+	const cheatsheetViewProvider: FountainCheatSheetWebviewViewProvider = new FountainCheatSheetWebviewViewProvider(context.extensionUri);
 	vscode.window.registerWebviewViewProvider("fountain-cheatsheet",cheatsheetViewProvider);
 
 	//Register for line duration length

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,6 +97,7 @@ import { createStatisticsPanel, FountainStatsPanelserializer as FountainStatsPan
 import { FountainOutlineTreeDataProvider } from "./providers/Outline";
 import { performance } from "perf_hooks";
 import { exportHtml } from "./providers/StaticHtml";
+import { FountainCheatSheetTreeDataProvider } from "./providers/Cheatsheet";
 
 
 /**
@@ -124,6 +125,7 @@ function updateStatus(lengthAction: number, lengthDialogue: number): void {
 var durationStatus: vscode.StatusBarItem;
 const outlineViewProvider: FountainOutlineTreeDataProvider = new FountainOutlineTreeDataProvider();
 const commandViewProvider: FountainCommandTreeDataProvider = new FountainCommandTreeDataProvider();
+const cheatsheetViewProvider: FountainCheatSheetTreeDataProvider = new FountainCheatSheetTreeDataProvider();
 var lastShiftedParseId = "";
 
 export let diagnosticCollection = languages.createDiagnosticCollection("fountain");
@@ -217,6 +219,10 @@ export function activate(context: ExtensionContext) {
 	//Register command tree view
 	vscode.window.registerTreeDataProvider("fountain-commands", outlineViewProvider)
 	vscode.window.createTreeView("fountain-commands", { treeDataProvider: commandViewProvider });
+
+	//Register cheatsheet tree view
+	vscode.window.registerTreeDataProvider("fountain-cheatsheet",cheatsheetViewProvider);
+	vscode.window.createTreeView("fountain-cheatsheet",{ treeDataProvider: cheatsheetViewProvider });
 
 	//Register for line duration length
 	durationStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -97,7 +97,7 @@ import { createStatisticsPanel, FountainStatsPanelserializer as FountainStatsPan
 import { FountainOutlineTreeDataProvider } from "./providers/Outline";
 import { performance } from "perf_hooks";
 import { exportHtml } from "./providers/StaticHtml";
-import { FountainCheatSheetTreeDataProvider } from "./providers/Cheatsheet";
+import { FountainCheatSheetWebviewViewProvider } from "./providers/Cheatsheet";
 
 
 /**
@@ -125,7 +125,7 @@ function updateStatus(lengthAction: number, lengthDialogue: number): void {
 var durationStatus: vscode.StatusBarItem;
 const outlineViewProvider: FountainOutlineTreeDataProvider = new FountainOutlineTreeDataProvider();
 const commandViewProvider: FountainCommandTreeDataProvider = new FountainCommandTreeDataProvider();
-const cheatsheetViewProvider: FountainCheatSheetTreeDataProvider = new FountainCheatSheetTreeDataProvider();
+const cheatsheetViewProvider: FountainCheatSheetWebviewViewProvider = new FountainCheatSheetWebviewViewProvider();
 var lastShiftedParseId = "";
 
 export let diagnosticCollection = languages.createDiagnosticCollection("fountain");
@@ -220,9 +220,8 @@ export function activate(context: ExtensionContext) {
 	vscode.window.registerTreeDataProvider("fountain-commands", outlineViewProvider)
 	vscode.window.createTreeView("fountain-commands", { treeDataProvider: commandViewProvider });
 
-	//Register cheatsheet tree view
-	vscode.window.registerTreeDataProvider("fountain-cheatsheet",cheatsheetViewProvider);
-	vscode.window.createTreeView("fountain-cheatsheet",{ treeDataProvider: cheatsheetViewProvider });
+	//Register cheatsheet web view
+	vscode.window.registerWebviewViewProvider("fountain-cheatsheet",cheatsheetViewProvider);
 
 	//Register for line duration length
 	durationStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100);

--- a/src/providers/Cheatsheet.ts
+++ b/src/providers/Cheatsheet.ts
@@ -1,18 +1,20 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
 
 export class FountainCheatSheetWebviewViewProvider implements vscode.WebviewViewProvider {
-    _extensionUri= vscode.extensions.getExtension("piersdeseilligny.betterfountain").extensionPath;
     
+    constructor(
+		private readonly _extensionUri: vscode.Uri,
+	) { }
+
     resolveWebviewView(webviewView: vscode.WebviewView, _context: vscode.WebviewViewResolveContext<unknown>, _token: vscode.CancellationToken): void | Thenable<void> {
        
         webviewView.webview.options = {
 			localResourceRoots: [
-				vscode.Uri.parse(this._extensionUri)
+				this._extensionUri
 			]
 		};
        
-        const cssDiskPath = vscode.Uri.file(path.join(this._extensionUri, 'out', 'webviews', 'cheatsheet.css'));
+        const cssDiskPath = vscode.Uri.joinPath(this._extensionUri, 'out', 'webviews', 'cheatsheet.css');
         const styleUri = webviewView.webview.asWebviewUri(cssDiskPath).toString()
 
         webviewView.webview.html = `<!DOCTYPE html>
@@ -24,7 +26,7 @@ export class FountainCheatSheetWebviewViewProvider implements vscode.WebviewView
             
            
             <title>Cheat Sheet</title>
-            <link rel='stylesheet' type='text/css' href='${styleUri}'>
+            <link rel="stylesheet" href="${styleUri}">
 
         </head>
         <body>

--- a/src/providers/Cheatsheet.ts
+++ b/src/providers/Cheatsheet.ts
@@ -15,19 +15,50 @@ export class FountainCheatSheetWebviewViewProvider implements vscode.WebviewView
 		};
        
         const cssDiskPath = vscode.Uri.joinPath(this._extensionUri, 'out', 'webviews', 'cheatsheet.css');
-        const styleUri = webviewView.webview.asWebviewUri(cssDiskPath).toString()
+        const styleUri = webviewView.webview.asWebviewUri(cssDiskPath).toString();
+        const codiconDiskPath = vscode.Uri.joinPath(this._extensionUri, 'node_modules', 'vscode-codicons', 'dist', 'codicon.css');
+        const codiconUri = webviewView.webview.asWebviewUri(codiconDiskPath).toString();
+
+        const fontUri = webviewView.webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'out', 'courierprime', 'courier-prime.ttf')).toString();
+        const fontUriBold = webviewView.webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'out', 'courierprime', 'courier-prime-bold.ttf')).toString();
+        const fontUriItalic = webviewView.webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'out', 'courierprime', 'courier-prime-italic.ttf')).toString();
+        const fontUriBoldItalic = webviewView.webview.asWebviewUri(vscode.Uri.joinPath(this._extensionUri, 'out', 'courierprime', 'courier-prime-bold-italic.ttf')).toString();
 
         webviewView.webview.html = `<!DOCTYPE html>
         <html lang="en">
         <head>
             <meta charset="UTF-8">
-            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webviewView.webview.cspSource}; ">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webviewView.webview.cspSource} 'unsafe-inline'; font-src https://* file://*">
             <meta name="viewport" content="width=device-width, initial-scale=1.0">
             
            
             <title>Cheat Sheet</title>
             <link rel="stylesheet" href="${styleUri}">
-
+            <link rel="stylesheet" type="text/css" href="${codiconUri}">
+            <style>
+            @font-face{
+                font-family: betterfountain-screenplayfont;
+                src:url(${fontUri});
+                font-weight: normal;
+            }
+            @font-face{
+                font-family: betterfountain-screenplayfont;
+                src:url(${fontUriBold});
+                font-weight: bold;
+            }
+            @font-face{
+                font-family: betterfountain-screenplayfont;
+                src:url(${fontUriItalic});
+                font-weight: normal;
+                font-style: italic;
+            }
+            @font-face{
+                font-family: betterfountain-screenplayfont;
+                src:url(${fontUriBoldItalic});
+                font-weight: bold;
+                font-style: italic;
+            }
+            </style>
         </head>
         <body>
             ${getCheatSheetAsHtml()}
@@ -50,9 +81,8 @@ function getCheatSheetAsHtml(){
     getCheatSheet().forEach((cheatsheetItems,categoryName)=>{
         result += `<details class="category"><summary><span class="">${categoryName}</span></summary><div>`
         cheatsheetItems.forEach(item=>{
-            result+= `<details class="cheat-item"><summary><span class="keyword">${item.keyword}</span> ${item.description}</summary> 
-            <p>E.g.:</p>
-            <p>${item.example}</p>
+            result+= `<details class="cheat-item"><summary><span class="keyword">${item.keyword}</span> <span>${item.description}</span></summary> 
+            <p class="example">${item.example}</p>
             </details>`
         })
         result += "</div></details>"
@@ -64,66 +94,66 @@ function getCheatSheetAsHtml(){
 function getCheatSheet(): Map<string,CheatsheetItem[]>{
     let cheatSheet: Map<string,CheatsheetItem[]> = new Map<string,CheatsheetItem[]>();
     cheatSheet.set('Scenes', [
-        new CheatsheetItem("INT.","Indoor scene","INT. BRICK'S ROOM - DAY"),
-        new CheatsheetItem("EXT.","Outdoor scene","EXT. BRICK'S POOL - DAY"),
-        new CheatsheetItem("EST.","Establishing scene","EST. CITY - NIGHT"),
-        new CheatsheetItem("INT./EXT.","Indoor and Outdoor scene","INT./EXT. RONNA'S CAR - NIGHT [DRIVING]"),
-        new CheatsheetItem("I/E.","Indoor and Outdoor scene","I/E. RONNA'S CAR - NIGHT [DRIVING]"),
+        new CheatsheetItem("INT.","Indoor scene","<span class='scene'>INT. BRICK'S ROOM - DAY</span>"),
+        new CheatsheetItem("EXT.","Outdoor scene","<span class='scene'>EXT. BRICK'S POOL - DAY</span>"),
+        new CheatsheetItem("EST.","Establishing scene","<span class='scene'>EST. CITY - NIGHT</span>"),
+        new CheatsheetItem("INT./EXT.","Indoor and Outdoor scene","<span class='scene'>INT./EXT. RONNA'S CAR - NIGHT [DRIVING]</span>"),
+        new CheatsheetItem("I/E.","Indoor and Outdoor scene","<span class='scene'>I/E. RONNA'S CAR - NIGHT [DRIVING]</span>"),
         new CheatsheetItem("TO:","Transitions should be upper case, ending in ' TO:'"
-                                ,"Jack begins to argue vociferously in Vietnamese (?), But mercifully we...\n\nCUT TO:\n\nEXT. BRICK'S POOL - DAY"),
+                                ,"Jack begins to argue vociferously in Vietnamese (?), But mercifully we...\n\n<span class='transition'>CUT TO:</span>\n\n<span class='scene'>EXT. BRICK'S POOL - DAY</span>"),
         new CheatsheetItem("","Action, or scene description, is any paragraph that doesn't meet criteria for another element"
                                 ,`They drink long and well from the beers.\n\nAnd then there's a long beat.\nLonger than is funny.\nLong enough to be depressing.\n\nThe men look at each other.`),   ])
 
     cheatSheet.set('Dialogues', [
-        new CheatsheetItem("","Character names should be in upper case","STEEL\nThe man's a myth!"),
+        new CheatsheetItem("","Character names should be in upper case","<span class='character'>STEEL</span>\n<span class='dialogue'>The man's a myth!</span>"),
         new CheatsheetItem("","Dialogue is any text following a Character or Parenthetical element"
-                                ,"SANBORN\nA good 'ole boy."),
+                                ,"<span class='character'>SANBORN</span>\n<span class='dialogue'>A good 'ole boy.</span>"),
         new CheatsheetItem("(parantheticals)","Parentheticals follow a Character or Dialogue element, and are wrapped in parentheses ()"
-                                ,"STEEL\n(starting the engine)\nSo much for retirement!"),
+                                ,"<span class='character'>STEEL</span>\n<span class='parenthetical'>(starting the engine)</span><span class='dialogue'>\nSo much for retirement!</span>"),
         new CheatsheetItem("^","Dual, or simultaneous, dialogue is expressed by adding a caret ^ after the second Character element"
-                                ,"BRICK\nScrew retirement.\n\nSTEEL ^\nScrew retirement."),
+                                ,"<span class='character'>BRICK</span>\n<span class='dialogue'>Screw retirement.</span>\n\n<span class='character'>STEEL</span><span class='caret'>^</span>\n<span class='dialogue'>Screw retirement.</span>"),
         new CheatsheetItem("~","Lyric lines start with a tilde ~"
-                                ,"~Willy Wonka! Willy Wonka! The amazing chocolatier!"),
+                                ,"<span class='lyrics'>~Willy Wonka! Willy Wonka! The amazing chocolatier!</span>"),
     ])
     
     cheatSheet.set('Emphasis', [
         new CheatsheetItem("","The optional Title Page is always the first thing in a Fountain document"
-        ,`Title:
-    _**BRICK & STEEL**_
-    _**FULL RETIRED**_
-Credit: Written by
-Author: Stu Maschwitz
-Source: Story by KTM
-Draft date: 1/20/2012
-Contact:
-    Next Level Productions
+        ,`<span class='tkey'>Title</span>:
+    <span class='tvalue'>_**BRICK & STEEL**_
+    _**FULL RETIRED**_</span>
+<span class='tkey'>Credit</span>: <span class='tvalue'>Written by</span>
+<span class='tkey'>Author</span>: <span class='tvalue'>Stu Maschwitz</span>
+<span class='tkey'>Source</span>: <span class='tvalue'>Story by KTM</span>
+<span class='tkey'>Draft date</span>: <span class='tvalue'>1/20/2012</span>
+<span class='tkey'>Contact</span>:
+<span class='tvalue'>Next Level Productions
     1588 Mission Dr.
-    Solvang, CA 93463`),
-        new CheatsheetItem(">CENTERED TEXT<","Centered text is bracketed with greater/less-than",">THE END<"),
-        new CheatsheetItem("*italics*","italics","*italics*"),
-        new CheatsheetItem("**bold**","Bold text","**bold**"),
-        new CheatsheetItem("***bold italics***","Bold and italics text","***bold italics***"),
-        new CheatsheetItem("_underline_","Underline text","_underline_"),
+    Solvang, CA 93463</span>`),
+        new CheatsheetItem(">CENTERED TEXT<","Centered text is bracketed with greater/less-than","<span class='centered'>&gt;THE END&lt;</span>"),
+        new CheatsheetItem("*italics*","italics","<span class='italics'>*italics*</span>"),
+        new CheatsheetItem("**bold**","Bold text","<span class='bold'>**bold**"),
+        new CheatsheetItem("***bold italics***","Bold and italics text","<span class='bold italics'>***bold italics***</span>"),
+        new CheatsheetItem("_underline_","Underline text","<span class='underline'>_underline_</span>"),
         new CheatsheetItem("===","Page Breaks are indicated by a line containing three or more consecutive = signs"
-                                ,">**End of Act One**<\n\n===\n\n>**Act Two**<"),
+                                ,"<span class='centered '>&gt;<span class='bold'>**End of Act One**</span>&lt;\n\n<span class='linebreak'>===</span>\n\n#Act Two"),
     ])
 
     cheatSheet.set('Misc.', [
         new CheatsheetItem("[[ notes ]]","A Note is created by enclosing some text with double brackets"
-        ,`INT. TRAILER HOME - DAY
+        ,`<span class='scene'>INT. TRAILER HOME - DAY</span>
 
-This is the home of THE BOY BAND, AKA DAN and JACK[[Or did we think of actual names for these guys?]].  They too are drinking beer, and counting the take from their last smash-and-grab.  Money, drugs, and ridiculous props are strewn about the table.
+This is the home of THE BOY BAND, AKA DAN and JACK<span class='note'>[[Or did we think of actual names for these guys?]]</span>.  They too are drinking beer, and counting the take from their last smash-and-grab.  Money, drugs, and ridiculous props are strewn about the table.
 
-[[It was supposed to be Vietnamese, right?]]
+<span class='note'>[[It was supposed to be Vietnamese, right?]]</span>
 
-JACK
-(in Vietnamese, subtitled)
-*Did you know Brick and Steel are retired?*`),
+<span class='character'>JACK</span>
+<span class='parenthetical'>(in Vietnamese, subtitled)</span>
+<span class='dialogue'>Did you know Brick and Steel are retired?</span>`),
         new CheatsheetItem("/* ignore text */","If you want Fountain to ignore some text, wrap it with /* some text */"
-                                ,"/*\nINT. GARAGE - DAY\n\nBRICK and STEEL get into Mom's PORSCHE, Steel at the wheel.*/"),
+                                ,"<span class='boneyard'>/*\nINT. GARAGE - DAY\n\nBRICK and STEEL get into Mom's PORSCHE, Steel at the wheel.*/</span>"),
         new CheatsheetItem("#","Create a Section by preceding a line with one or more pound-sign # characters"
-                                ,"# Act\n\n## Sequence\n\n### Scene\n\n## Another Sequence\n\n# Another Act"),
-        new CheatsheetItem("=","Synopses are single lines prefixed by an equals sign =","# ACT I\n\n= Set up the characters and the story."),
+                                ,"<span class='sequence'># Act\n\n## Sequence\n\n</span><span class='scene'>INT. SCENE IN HOUSE - DAY</span>"),
+        new CheatsheetItem("=","Synopses are single lines prefixed by an equals sign =","<span class='sequence'># ACT I</span>\n\n<span class='synopse'>= Set up the characters and the story.</span>"),
     ])
 
     return cheatSheet;

--- a/src/providers/Cheatsheet.ts
+++ b/src/providers/Cheatsheet.ts
@@ -1,81 +1,91 @@
 import * as vscode from 'vscode';
-export class FountainCheatSheetTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
-    public readonly onDidChangeTreeDataEmitter: vscode.EventEmitter<vscode.TreeItem | null> =
-        new vscode.EventEmitter<vscode.TreeItem | null>();
+import * as path from 'path';
 
-    rootTree : CheatsheetTreeItem;
-    public readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | null> = this.onDidChangeTreeDataEmitter.event;
-    getTreeItem(element: vscode.TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
-        return element;
-    }
-    getChildren(element?: CheatsheetTreeItem): vscode.ProviderResult<vscode.TreeItem[]> {
-        if (element)
-            return element.children;
-        else
-            return this.buildTree();
-    }
-    getParent?(element: CheatsheetTreeItem): vscode.ProviderResult<vscode.TreeItem> {
-        return element.parent;
-    }
+export class FountainCheatSheetWebviewViewProvider implements vscode.WebviewViewProvider {
+    _extensionUri= vscode.extensions.getExtension("piersdeseilligny.betterfountain").extensionPath;
+    
+    resolveWebviewView(webviewView: vscode.WebviewView, _context: vscode.WebviewViewResolveContext<unknown>, _token: vscode.CancellationToken): void | Thenable<void> {
+       
+        webviewView.webview.options = {
+			localResourceRoots: [
+				vscode.Uri.parse(this._extensionUri)
+			]
+		};
+       
+        const cssDiskPath = vscode.Uri.file(path.join(this._extensionUri, 'out', 'webviews', 'cheatsheet.css'));
+        const styleUri = webviewView.webview.asWebviewUri(cssDiskPath).toString()
 
-    buildTree(): CheatsheetTreeItem[] {
-        let categoriesTree : CheatsheetTreeItem[] = [];
-        getCheatSheet().forEach((cheatsheetItems,categoryName)=>{
-            let category:CheatsheetTreeItem = new CheatsheetTreeItem(categoryName,null,null);
-            cheatsheetItems.map((item) => new CheatsheetTreeItem(item,category, item.example))
-                .forEach((item) => category.children.push(item));
-            category.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
-            categoriesTree.push(category);
-        })
-        return categoriesTree;
+        webviewView.webview.html = `<!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webviewView.webview.cspSource}; ">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            
+           
+            <title>Cheat Sheet</title>
+            <link rel='stylesheet' type='text/css' href='${styleUri}'>
+
+        </head>
+        <body>
+            ${getCheatSheetAsHtml()}
+        </body>
+        </html>`;
     }
 }
 
-class CheatsheetTreeItem extends vscode.TreeItem {
-    children: CheatsheetTreeItem[] = [];
-    constructor(label: string | CheatsheetItemLabel, public parent: CheatsheetTreeItem, public tooltip: string) {
-        super(label);
-        this.tooltip = tooltip;
-    }
-}
-
-class CheatsheetItemLabel implements vscode.TreeItemLabel {
+class CheatsheetItem  {
     label: string;
     highlights?: [number, number][];
-
-    constructor(keyword: string, description: string, public example: string) {
+    constructor( public keyword: string, public description: string, public example: string) {
         this.label = `${keyword} ${description}`.trim()
         this.highlights = [[0, keyword.length]]
     }
 }
 
-function getCheatSheet(): Map<string,CheatsheetItemLabel[]>{
-    let cheatSheet: Map<string,CheatsheetItemLabel[]> = new Map<string,CheatsheetItemLabel[]>();
+function getCheatSheetAsHtml(){
+    let result:string = "";
+    getCheatSheet().forEach((cheatsheetItems,categoryName)=>{
+        result += `<details class="category"><summary><span class="">${categoryName}</span></summary>`
+        cheatsheetItems.forEach(item=>{
+            result+= `<details class="cheat-item"><summary><i class="keyword">${item.keyword}</i> ${item.description}</summary> 
+            <p>E.g.:</p>
+            <p>${item.example}</p>
+            </details>`
+        })
+        result += "</details>"
+        
+    })
+    return result;
+}
+
+function getCheatSheet(): Map<string,CheatsheetItem[]>{
+    let cheatSheet: Map<string,CheatsheetItem[]> = new Map<string,CheatsheetItem[]>();
     cheatSheet.set('Scenes', [
-        new CheatsheetItemLabel("INT.","Indoor scene","INT. BRICK'S ROOM - DAY"),
-        new CheatsheetItemLabel("EXT.","Outdoor scene","EXT. BRICK'S POOL - DAY"),
-        new CheatsheetItemLabel("EST.","Establishing scene",null),
-        new CheatsheetItemLabel("INT./EXT.","Indoor and Outdoor scene","INT./EXT. RONNA'S CAR - NIGHT [DRIVING]"),
-        new CheatsheetItemLabel("I/E.","Indoor and Outdoor scene","I/E. RONNA'S CAR - NIGHT [DRIVING]"),
-        new CheatsheetItemLabel("TO:","Transitions should be upper case, ending in ' TO:'"
+        new CheatsheetItem("INT.","Indoor scene","INT. BRICK'S ROOM - DAY"),
+        new CheatsheetItem("EXT.","Outdoor scene","EXT. BRICK'S POOL - DAY"),
+        new CheatsheetItem("EST.","Establishing scene","EST. CITY - NIGHT"),
+        new CheatsheetItem("INT./EXT.","Indoor and Outdoor scene","INT./EXT. RONNA'S CAR - NIGHT [DRIVING]"),
+        new CheatsheetItem("I/E.","Indoor and Outdoor scene","I/E. RONNA'S CAR - NIGHT [DRIVING]"),
+        new CheatsheetItem("TO:","Transitions should be upper case, ending in ' TO:'"
                                 ,"Jack begins to argue vociferously in Vietnamese (?), But mercifully we...\n\nCUT TO:\n\nEXT. BRICK'S POOL - DAY"),
-        new CheatsheetItemLabel("","Action, or scene description, is any paragraph that doesn't meet criteria for another element"
+        new CheatsheetItem("","Action, or scene description, is any paragraph that doesn't meet criteria for another element"
                                 ,`They drink long and well from the beers.\n\nAnd then there's a long beat.\nLonger than is funny.\nLong enough to be depressing.\n\nThe men look at each other.`),   ])
 
     cheatSheet.set('Dialogues', [
-        new CheatsheetItemLabel("","Character names should be in upper case","STEEL\nThe man's a myth!"),
-        new CheatsheetItemLabel("","Dialogue is any text following a Character or Parenthetical element"
+        new CheatsheetItem("","Character names should be in upper case","STEEL\nThe man's a myth!"),
+        new CheatsheetItem("","Dialogue is any text following a Character or Parenthetical element"
                                 ,"SANBORN\nA good 'ole boy."),
-        new CheatsheetItemLabel("(parantheticals)","Parentheticals follow a Character or Dialogue element, and are wrapped in parentheses ()"
+        new CheatsheetItem("(parantheticals)","Parentheticals follow a Character or Dialogue element, and are wrapped in parentheses ()"
                                 ,"STEEL\n(starting the engine)\nSo much for retirement!"),
-        new CheatsheetItemLabel("^","Dual, or simultaneous, dialogue is expressed by adding a caret ^ after the second Character element"
+        new CheatsheetItem("^","Dual, or simultaneous, dialogue is expressed by adding a caret ^ after the second Character element"
                                 ,"BRICK\nScrew retirement.\n\nSTEEL ^\nScrew retirement."),
-        new CheatsheetItemLabel("~","Lyric lines start with a tilde ~"
+        new CheatsheetItem("~","Lyric lines start with a tilde ~"
                                 ,"~Willy Wonka! Willy Wonka! The amazing chocolatier!"),
     ])
     
     cheatSheet.set('Emphasis', [
-        new CheatsheetItemLabel("","The optional Title Page is always the first thing in a Fountain document"
+        new CheatsheetItem("","The optional Title Page is always the first thing in a Fountain document"
         ,`Title:
     _**BRICK & STEEL**_
     _**FULL RETIRED**_
@@ -87,17 +97,17 @@ Contact:
     Next Level Productions
     1588 Mission Dr.
     Solvang, CA 93463`),
-        new CheatsheetItemLabel(">CENTERED TEXT<","Centered text is bracketed with greater/less-than",">THE END<"),
-        new CheatsheetItemLabel("*italics*","italics","*italics*"),
-        new CheatsheetItemLabel("**bold**","Bold text","**bold**"),
-        new CheatsheetItemLabel("***bold italics***","Bold and italics text","***bold italics***"),
-        new CheatsheetItemLabel("_underline_","Underline text","_underline_"),
-        new CheatsheetItemLabel("===","Page Breaks are indicated by a line containing three or more consecutive = signs"
+        new CheatsheetItem(">CENTERED TEXT<","Centered text is bracketed with greater/less-than",">THE END<"),
+        new CheatsheetItem("*italics*","italics","*italics*"),
+        new CheatsheetItem("**bold**","Bold text","**bold**"),
+        new CheatsheetItem("***bold italics***","Bold and italics text","***bold italics***"),
+        new CheatsheetItem("_underline_","Underline text","_underline_"),
+        new CheatsheetItem("===","Page Breaks are indicated by a line containing three or more consecutive = signs"
                                 ,">**End of Act One**<\n\n===\n\n>**Act Two**<"),
     ])
 
     cheatSheet.set('Misc.', [
-        new CheatsheetItemLabel("[[ notes ]]","A Note is created by enclosing some text with double brackets"
+        new CheatsheetItem("[[ notes ]]","A Note is created by enclosing some text with double brackets"
         ,`INT. TRAILER HOME - DAY
 
 This is the home of THE BOY BAND, AKA DAN and JACK[[Or did we think of actual names for these guys?]].  They too are drinking beer, and counting the take from their last smash-and-grab.  Money, drugs, and ridiculous props are strewn about the table.
@@ -107,11 +117,11 @@ This is the home of THE BOY BAND, AKA DAN and JACK[[Or did we think of actual na
 JACK
 (in Vietnamese, subtitled)
 *Did you know Brick and Steel are retired?*`),
-        new CheatsheetItemLabel("/* ignore text */","If you want Fountain to ignore some text, wrap it with /* some text */"
+        new CheatsheetItem("/* ignore text */","If you want Fountain to ignore some text, wrap it with /* some text */"
                                 ,"/*\nINT. GARAGE - DAY\n\nBRICK and STEEL get into Mom's PORSCHE, Steel at the wheel.*/"),
-        new CheatsheetItemLabel("#","Create a Section by preceding a line with one or more pound-sign # characters"
+        new CheatsheetItem("#","Create a Section by preceding a line with one or more pound-sign # characters"
                                 ,"# Act\n\n## Sequence\n\n### Scene\n\n## Another Sequence\n\n# Another Act"),
-        new CheatsheetItemLabel("=","Synopses are single lines prefixed by an equals sign =","# ACT I\n\n= Set up the characters and the story."),
+        new CheatsheetItem("=","Synopses are single lines prefixed by an equals sign =","# ACT I\n\n= Set up the characters and the story."),
     ])
 
     return cheatSheet;

--- a/src/providers/Cheatsheet.ts
+++ b/src/providers/Cheatsheet.ts
@@ -46,14 +46,14 @@ class CheatsheetItem  {
 function getCheatSheetAsHtml(){
     let result:string = "";
     getCheatSheet().forEach((cheatsheetItems,categoryName)=>{
-        result += `<details class="category"><summary><span class="">${categoryName}</span></summary>`
+        result += `<details class="category"><summary><span class="">${categoryName}</span></summary><div>`
         cheatsheetItems.forEach(item=>{
-            result+= `<details class="cheat-item"><summary><i class="keyword">${item.keyword}</i> ${item.description}</summary> 
+            result+= `<details class="cheat-item"><summary><span class="keyword">${item.keyword}</span> ${item.description}</summary> 
             <p>E.g.:</p>
             <p>${item.example}</p>
             </details>`
         })
-        result += "</details>"
+        result += "</div></details>"
         
     })
     return result;

--- a/src/providers/Cheatsheet.ts
+++ b/src/providers/Cheatsheet.ts
@@ -1,0 +1,118 @@
+import * as vscode from 'vscode';
+export class FountainCheatSheetTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
+    public readonly onDidChangeTreeDataEmitter: vscode.EventEmitter<vscode.TreeItem | null> =
+        new vscode.EventEmitter<vscode.TreeItem | null>();
+
+    rootTree : CheatsheetTreeItem;
+    public readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | null> = this.onDidChangeTreeDataEmitter.event;
+    getTreeItem(element: vscode.TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
+        return element;
+    }
+    getChildren(element?: CheatsheetTreeItem): vscode.ProviderResult<vscode.TreeItem[]> {
+        if (element)
+            return element.children;
+        else
+            return this.buildTree();
+    }
+    getParent?(element: CheatsheetTreeItem): vscode.ProviderResult<vscode.TreeItem> {
+        return element.parent;
+    }
+
+    buildTree(): CheatsheetTreeItem[] {
+        let categoriesTree : CheatsheetTreeItem[] = [];
+        getCheatSheet().forEach((cheatsheetItems,categoryName)=>{
+            let category:CheatsheetTreeItem = new CheatsheetTreeItem(categoryName,null,null);
+            cheatsheetItems.map((item) => new CheatsheetTreeItem(item,category, item.example))
+                .forEach((item) => category.children.push(item));
+            category.collapsibleState = vscode.TreeItemCollapsibleState.Collapsed;
+            categoriesTree.push(category);
+        })
+        return categoriesTree;
+    }
+}
+
+class CheatsheetTreeItem extends vscode.TreeItem {
+    children: CheatsheetTreeItem[] = [];
+    constructor(label: string | CheatsheetItemLabel, public parent: CheatsheetTreeItem, public tooltip: string) {
+        super(label);
+        this.tooltip = tooltip;
+    }
+}
+
+class CheatsheetItemLabel implements vscode.TreeItemLabel {
+    label: string;
+    highlights?: [number, number][];
+
+    constructor(keyword: string, description: string, public example: string) {
+        this.label = `${keyword} ${description}`.trim()
+        this.highlights = [[0, keyword.length]]
+    }
+}
+
+function getCheatSheet(): Map<string,CheatsheetItemLabel[]>{
+    let cheatSheet: Map<string,CheatsheetItemLabel[]> = new Map<string,CheatsheetItemLabel[]>();
+    cheatSheet.set('Scenes', [
+        new CheatsheetItemLabel("INT.","Indoor scene","INT. BRICK'S ROOM - DAY"),
+        new CheatsheetItemLabel("EXT.","Outdoor scene","EXT. BRICK'S POOL - DAY"),
+        new CheatsheetItemLabel("EST.","Establishing scene",null),
+        new CheatsheetItemLabel("INT./EXT.","Indoor and Outdoor scene","INT./EXT. RONNA'S CAR - NIGHT [DRIVING]"),
+        new CheatsheetItemLabel("I/E.","Indoor and Outdoor scene","I/E. RONNA'S CAR - NIGHT [DRIVING]"),
+        new CheatsheetItemLabel("TO:","Transitions should be upper case, ending in ' TO:'"
+                                ,"Jack begins to argue vociferously in Vietnamese (?), But mercifully we...\n\nCUT TO:\n\nEXT. BRICK'S POOL - DAY"),
+        new CheatsheetItemLabel("","Action, or scene description, is any paragraph that doesn't meet criteria for another element"
+                                ,`They drink long and well from the beers.\n\nAnd then there's a long beat.\nLonger than is funny.\nLong enough to be depressing.\n\nThe men look at each other.`),   ])
+
+    cheatSheet.set('Dialogues', [
+        new CheatsheetItemLabel("","Character names should be in upper case","STEEL\nThe man's a myth!"),
+        new CheatsheetItemLabel("","Dialogue is any text following a Character or Parenthetical element"
+                                ,"SANBORN\nA good 'ole boy."),
+        new CheatsheetItemLabel("(parantheticals)","Parentheticals follow a Character or Dialogue element, and are wrapped in parentheses ()"
+                                ,"STEEL\n(starting the engine)\nSo much for retirement!"),
+        new CheatsheetItemLabel("^","Dual, or simultaneous, dialogue is expressed by adding a caret ^ after the second Character element"
+                                ,"BRICK\nScrew retirement.\n\nSTEEL ^\nScrew retirement."),
+        new CheatsheetItemLabel("~","Lyric lines start with a tilde ~"
+                                ,"~Willy Wonka! Willy Wonka! The amazing chocolatier!"),
+    ])
+    
+    cheatSheet.set('Emphasis', [
+        new CheatsheetItemLabel("","The optional Title Page is always the first thing in a Fountain document"
+        ,`Title:
+    _**BRICK & STEEL**_
+    _**FULL RETIRED**_
+Credit: Written by
+Author: Stu Maschwitz
+Source: Story by KTM
+Draft date: 1/20/2012
+Contact:
+    Next Level Productions
+    1588 Mission Dr.
+    Solvang, CA 93463`),
+        new CheatsheetItemLabel(">CENTERED TEXT<","Centered text is bracketed with greater/less-than",">THE END<"),
+        new CheatsheetItemLabel("*italics*","italics","*italics*"),
+        new CheatsheetItemLabel("**bold**","Bold text","**bold**"),
+        new CheatsheetItemLabel("***bold italics***","Bold and italics text","***bold italics***"),
+        new CheatsheetItemLabel("_underline_","Underline text","_underline_"),
+        new CheatsheetItemLabel("===","Page Breaks are indicated by a line containing three or more consecutive = signs"
+                                ,">**End of Act One**<\n\n===\n\n>**Act Two**<"),
+    ])
+
+    cheatSheet.set('Misc.', [
+        new CheatsheetItemLabel("[[ notes ]]","A Note is created by enclosing some text with double brackets"
+        ,`INT. TRAILER HOME - DAY
+
+This is the home of THE BOY BAND, AKA DAN and JACK[[Or did we think of actual names for these guys?]].  They too are drinking beer, and counting the take from their last smash-and-grab.  Money, drugs, and ridiculous props are strewn about the table.
+
+[[It was supposed to be Vietnamese, right?]]
+
+JACK
+(in Vietnamese, subtitled)
+*Did you know Brick and Steel are retired?*`),
+        new CheatsheetItemLabel("/* ignore text */","If you want Fountain to ignore some text, wrap it with /* some text */"
+                                ,"/*\nINT. GARAGE - DAY\n\nBRICK and STEEL get into Mom's PORSCHE, Steel at the wheel.*/"),
+        new CheatsheetItemLabel("#","Create a Section by preceding a line with one or more pound-sign # characters"
+                                ,"# Act\n\n## Sequence\n\n### Scene\n\n## Another Sequence\n\n# Another Act"),
+        new CheatsheetItemLabel("=","Synopses are single lines prefixed by an equals sign =","# ACT I\n\n= Set up the characters and the story."),
+    ])
+
+    return cheatSheet;
+}

--- a/webviews/src/cheatsheet.css
+++ b/webviews/src/cheatsheet.css
@@ -1,0 +1,30 @@
+details > summary {
+    cursor: pointer;
+}
+
+details.category {
+    margin-bottom: 0.25em;
+    padding: 0.25em;
+}
+
+details.cheat-item {
+    padding: 0.5em;
+    border-radius: 0.5em;
+    border-style: outset;
+    margin-left: 0.5em;
+    border-color: #2b2b2b;
+    margin-bottom: 0.25em;
+    border-width: thin;
+}
+
+details.cheat-item > p {
+    font-size: small;
+    white-space: pre-wrap;
+}
+details.cheat-item .keyword{
+    color: lightcoral;
+}
+
+.category > summary {
+    font-size: 1.1em;
+}

--- a/webviews/src/cheatsheet.css
+++ b/webviews/src/cheatsheet.css
@@ -1,7 +1,17 @@
+body {
+    padding: 0 10px;
+}
+
 details > summary {
     cursor: pointer;
 }
 
+details.category > div {
+    margin-left: 0.3em;
+    border-left-style: inset;
+    border-left-color: lightgrey;
+    border-left-width: thin;
+}
 details.category {
     margin-bottom: 0.25em;
     padding: 0.25em;

--- a/webviews/src/cheatsheet.css
+++ b/webviews/src/cheatsheet.css
@@ -1,40 +1,137 @@
 body {
-    padding: 0 10px;
+    padding: 0px;
+    user-select: none;
 }
 
 details > summary {
     cursor: pointer;
 }
 
-details.category > div {
-    margin-left: 0.3em;
-    border-left-style: inset;
-    border-left-color: lightgrey;
-    border-left-width: thin;
-}
-details.category {
-    margin-bottom: 0.25em;
-    padding: 0.25em;
+details .example{
+    font-family: betterfountain-screenplayfont;
 }
 
+details.category>div{
+    position:relative;
+}
+
+details.category>div::before, details.cheat-item>p::before {
+    position: absolute;
+    content: '';
+    height: 100%;
+    width: 1px;
+    left:16px;
+    opacity:0.2;
+    background-color: var(--vscode-foreground);
+}
+details.cheat-item>p::before{
+    left:13px;
+    top:0;
+}
 details.cheat-item {
-    padding: 0.5em;
-    border-radius: 0.5em;
-    border-style: outset;
-    margin-left: 0.5em;
-    border-color: #2b2b2b;
-    margin-bottom: 0.25em;
-    border-width: thin;
+    line-height: 16px;
+    padding: 3px 12px 3px 24px;
+}
+
+details.cheat-item > summary > span{
+    color:var(--vscode-foreground);
+    opacity:0.7;
+}
+details.cheat-item > summary > span.keyword{
+    opacity:1;
+    font-weight: bold;
+    color:#d38d58;
 }
 
 details.cheat-item > p {
     font-size: small;
     white-space: pre-wrap;
-}
-details.cheat-item .keyword{
-    color: lightcoral;
+    margin-left: -7px;
+    padding-left: 32px;
+    margin-top: 0;
+    margin-bottom: 0;
+    margin-right: -11px;
+    padding-top: 4px;
+    padding-bottom: 0px;
+    position:relative;
 }
 
 .category > summary {
-    font-size: 1.1em;
+    line-height: 22px;
+    padding: 0 12px;
+}
+.category > summary:hover, details.cheat-item:hover {
+    background-color: var(--vscode-list-hoverBackground);
+}
+
+details > summary::before{
+    font-family: 'codicon';
+    font-size:14px;
+    content: '\eab6';
+    vertical-align: bottom;
+}
+::marker {
+    content:'';
+}
+details[open] > summary::before{
+    content:'\eab4';
+}
+
+.scene{
+    color:#569cd6;
+}
+.sequence{
+    font-weight: bold;
+    color:#569cd6;
+}
+.transition{
+    color:#b5cea8;
+}
+.character{
+color:#4ec9b0;
+}
+.dialogue{
+    color:#ce9178
+}
+.parenthetical{
+    color:#d7ba7d;
+}
+.caret{
+    color:#d7ba7d;
+}
+.tkey{
+    color:#569cd6;
+}
+.tvalue{
+color:#ce9178;
+}
+.centered{
+font-weight: bold;
+color:#569cd6;
+}
+.bold{
+    font-weight: bold;
+    color:#569cd6;
+}
+.italics{
+    font-style: italic;
+}
+.underline{
+text-decoration: underline;
+}
+.linebreak{
+
+}
+.note{
+color:#6a9955;
+}
+.boneyard{
+    color:#6a9955;
+}
+.synopse{
+    color:#6a9955;
+}
+.lyrics{
+    color:#ce9178;
+    font-style:italic;
 }


### PR DESCRIPTION
Added 'Cheat Sheet' section to the extension sidebar, were users can quickly refer to the basic fountain syntaxes.
I have grouped the cheats into categories, to better organize them.
Got most of the description and examples from [fountain.io](https://fountain.io/syntax).

**Screenshot**
![cheat-sheet-2](https://user-images.githubusercontent.com/8808797/159174524-b0fd4050-78ee-460c-8cf9-297d10bb28d9.png)

**Usage**
When users click on the extension's icon in the side bar, 'Cheat Sheet' tree will be shown with tree items for multiple categories.
Users can expand the category to find about fountain syntax for various items.
If the syntax has a keyword/character then that keyword/character will be highlighted at the start of the list item. Following it a simple description of the syntax is shown. 
Users can hover over any item to see an example for the particular syntax.

![tooltip](https://user-images.githubusercontent.com/8808797/159173828-7078fb1b-cb7a-4bae-a528-96c2dabed4b3.png)
