### PR TITLE
Sets default texture and scene numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
 							"paper"
 						],
 						"description": "The theme to be used in the live preview",
-						"default": "paper"
+						"default": "vscode"
 					},
 					"fountain.general.previewTexture": {
 						"type": "boolean",
@@ -253,7 +253,7 @@
 							"right",
 							"both"
 						],
-						"default": "none",
+						"default": "both",
 						"description": "Location of scene numbers"
 					},
 					"fountain.pdf.eachSceneOnNewPage": {


### PR DESCRIPTION
Set the default texture of webview to “vscode” and the scene numbers to “both” by default.