### PR TITLE
Fix pdfmaker support for colors specified in print config

### DIFF
--- a/src/pdf/pdfmaker.ts
+++ b/src/pdf/pdfmaker.ts
@@ -263,7 +263,7 @@ async function initDoc(opts: Options) {
                     link: linkurl,
                     font: font,
                     underline: linkurl || doc.format_state.underline,
-                    color: doc.format_state.override_color ? doc.format_state.override_color : 'black'
+                    color: doc.format_state.override_color ? doc.format_state.override_color : color
                 });
             }
             currentIndex += elem.length;


### PR DESCRIPTION
Use the actual calculated fill color when generating a textbox instead of hardcoding `'black'`.

The changes in regards to the pdf titlepage did break the custom colors specified in the print configuration when generating a pdf. Notably, the synopsis was always rendered in black instead of the ~50% grey. But this also affects the header and footer that are rendered with explicit color values.