### PR TITLE
Fix/improve HTML output

### DIFF
--- a/assets/staticexport.html
+++ b/assets/staticexport.html
@@ -315,6 +315,7 @@ div#titlepage {
 
         #workspace #script .page p.synopsis {
             opacity:0.4;
+            font-style: italic;
             margin-left: -20px
         }
 
@@ -350,10 +351,12 @@ div#titlepage {
         }
 
         .header {
+            opacity:0.4;
             position: absolute;
             top: 48px;
         }
         .footer{
+            opacity:0.4;
             position:absolute;
             bottom:48px
         }

--- a/assets/staticexport.html
+++ b/assets/staticexport.html
@@ -55,7 +55,7 @@
         }
         @font-face{
             font-family: betterfountain-screenplayfont;
-            src: url(data:font/ttf;base64,$COURIERPRIME-BOLD-ITALIC$) format('truetype');
+            src: url(data:font/ttf;base64,$COURIERPRIME-BOLDITALIC$) format('truetype');
             font-weight: bold;
             font-style: italic;
         }

--- a/webviews/src/preview.html
+++ b/webviews/src/preview.html
@@ -322,6 +322,7 @@ div#titlepage {
 
         #workspace #script .page p.synopsis {
             opacity:0.4;
+            font-style: italic;
             margin-left: -20px
         }
 
@@ -384,10 +385,12 @@ div#titlepage {
             height:auto !important;
         }
         .header {
+            opacity:0.4;
             position: absolute;
             top: 48px;
         }
         .footer{
+            opacity:0.4;
             position:absolute;
             bottom:48px
         }


### PR DESCRIPTION
The bold-italic variant of courier prime was not properly replaced due to a typo in the placeholder, leading sections in bold-italic being rendered in a different font (system default).

Also, make the synopsis italic and reduce the opacity of the header and footer in the generated html to follow the style of the pdf generator more closely.