### PR TITLE
Fix custom CONTINUED setting

### DIFF
--- a/src/configloader.ts
+++ b/src/configloader.ts
@@ -114,7 +114,7 @@ export var getFountainConfig = function(docuri:vscode.Uri):FountainConfig{
         invisible_section_bookmarks: pdfConfig.invisibleSectionBookmarks,
         text_more: pdfConfig.textMORE,
         text_contd: pdfConfig.textCONTD,
-        text_scene_continuation: pdfConfig.textSceneContinued,
+        text_scene_continued: pdfConfig.textSceneContinued,
         scene_continuation_top: pdfConfig.sceneContinuationTop,
         scene_continuation_bottom: pdfConfig.sceneContinuationBottom,
         synchronized_markup_and_preview: generalConfig.synchronizedMarkupAndPreview,

--- a/src/test/statistics.spec.ts
+++ b/src/test/statistics.spec.ts
@@ -55,7 +55,7 @@ const fountainConfig: FountainConfig  = {
     preview_texture: false,
     text_more:undefined as unknown as string,
     text_contd:undefined as unknown as string,
-    text_scene_continuation: undefined as unknown as string,
+    text_scene_continued: undefined as unknown as string,
     scene_continuation_top: false,
     scene_continuation_bottom: false,
     parenthetical_newline_helper: false,


### PR DESCRIPTION
The `fountain.pdf.textSceneContinued` config property was saved into a config object property called `text_scene_continuation`. However, it was later referenced as `text_scene_continued`. This caused the settings value to be ignored - exporting to PDF always writes `CONTINUED` regardless of the value in `fountain.pdf.textSceneContinued`.

This PR changes the property name in the config object so it matches the VS Code settings key.