### PR TITLE
Add support for highlighting changes in PDF export

### DIFF
--- a/package.json
+++ b/package.json
@@ -470,6 +470,9 @@
 		"test": "node node_modules/jest/bin/jest.js",
 		"open-in-browser": "vscode-test-web --extensionDevelopmentPath=. ."
 	},
+	"extensionDependencies": [
+		"vscode.git"
+	],
 	"devDependencies": {
 		"@types/base64-stream": "^1.0.2",
 		"@types/d3": "^5.16.4",

--- a/src/afterwriting-parser.ts
+++ b/src/afterwriting-parser.ts
@@ -394,6 +394,7 @@ export var parse = function (original_script: string, cfg: any, generate_html: b
 
 
         thistoken = create_token(text, current, i, new_line_length);
+        thistoken.original_line = i + 1;
         current = thistoken.end + 1;
 
         

--- a/src/configloader.ts
+++ b/src/configloader.ts
@@ -41,6 +41,7 @@ export class FountainConfig{
 
 export class ExportConfig {
     highlighted_characters: Array<String>;
+    highlighted_changes: { lines: Array<number>, highlightColor: Array<number> };
 }
 
 export type FountainUIPersistence = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -81,6 +81,7 @@ export function activate(context: ExtensionContext) {
   context.subscriptions.push(vscode.commands.registerCommand('fountain.exportpdf', commands.exportPdf));
   context.subscriptions.push(vscode.commands.registerCommand('fountain.exportpdfdebug', async () => commands.exportPdf(false, true)));
   context.subscriptions.push(vscode.commands.registerCommand('fountain.exportpdfcustom', async () => commands.exportPdf(true, false, true)));
+  context.subscriptions.push(vscode.commands.registerCommand('fountain.exportpdfchanges', async () => commands.exportPdf(true, false, false, true)));
   context.subscriptions.push(vscode.commands.registerCommand('fountain.exporthtml', exportHtml));
   context.subscriptions.push(vscode.commands.registerCommand('fountain.overwriteSceneNumbers', overwriteSceneNumbers));
   context.subscriptions.push(vscode.commands.registerCommand('fountain.updateSceneNumbers', updateSceneNumbers));

--- a/src/pdf/pdfmaker.ts
+++ b/src/pdf/pdfmaker.ts
@@ -684,6 +684,10 @@ async function generate(doc: any, opts: any, lineStructs?: Map<number, lineStruc
                         new_text_properties.bold = true;
                     }
                 };
+                if (!!expcfg && !!expcfg.highlighted_changes.lines && lline.token.original_line && expcfg.highlighted_changes.lines.includes(lline.token.original_line)) {
+                    new_text_properties.highlight = true;
+                    new_text_properties.highlightcolor = expcfg.highlighted_changes.highlightColor;
+                };
                 return new_text_properties
             }
 

--- a/src/providers/Commands.ts
+++ b/src/providers/Commands.ts
@@ -13,6 +13,8 @@ export class FountainCommandTreeDataProvider implements vscode.TreeDataProvider<
 		//const treeExportPdfDebug = new vscode.TreeItem("Export PDF with default name");
 		const treeExportPdfCustom= new vscode.TreeItem("Export PDF with highlighted characters");
 		treeExportPdfCustom.iconPath = new vscode.ThemeIcon("export");
+		const treeExportPdfChanges = new vscode.TreeItem("Export PDF with highlighted changes");
+		treeExportPdfChanges.iconPath = new vscode.ThemeIcon("export");
 		const treeExportHtml = new vscode.TreeItem("Export HTML");
 		treeExportHtml.iconPath = new vscode.ThemeIcon("export");
 		treeExportHtml.tooltip = "Export live preview as .html document"
@@ -41,6 +43,10 @@ export class FountainCommandTreeDataProvider implements vscode.TreeDataProvider<
 		};*/
 		treeExportPdfCustom.command = {
 			command: 'fountain.exportpdfcustom',
+			title: ''
+		};
+		treeExportPdfChanges.command = {
+			command: 'fountain.exportpdfchanges',
 			title: ''
 		};
 		treeExportHtml.command = {
@@ -74,6 +80,7 @@ export class FountainCommandTreeDataProvider implements vscode.TreeDataProvider<
 		elements.push(treeExportPdf);
 	//	elements.push(treeExportPdfDebug);
 		elements.push(treeExportPdfCustom);
+		elements.push(treeExportPdfChanges);
 		elements.push(treeExportHtml);
 		elements.push(treeLivePreview);
 		elements.push(treePdfPreview);

--- a/src/token.ts
+++ b/src/token.ts
@@ -14,6 +14,7 @@ export function create_token(text?: string, cursor?: number, line?: number, new_
         character:undefined,
         index:-1,
         takeNumber:-1,
+        original_line:undefined,
         is:function(...args:string[]){
             return args.indexOf(this.type) !== -1;
         },
@@ -71,6 +72,7 @@ export interface token {
     level:number;
     time:number;
     takeNumber:number;
+    original_line:number;
     is:Function;
     is_dialogue:Function;
     name:Function;


### PR DESCRIPTION
This PR adds the ability to highlight changes made to the screenplay based on the git commit history of the current document. This will improve the ability to communicate those changes to other people.

<img width="452" alt="SCR-20241031-jxqc" src="https://github.com/user-attachments/assets/e0e58292-c9bd-42c7-a15f-3c140f14d10c">

It lets the user select a commit to compare the most recent document commit to and highlights all changed or added lines in the PDF export. 

<img width="719" alt="SCR-20241031-jxtb" src="https://github.com/user-attachments/assets/19b9f33c-686b-40db-937f-4bb647ae1ec7">

The user is also able to choose a desired highlight color.

<img width="745" alt="SCR-20241031-jxxw" src="https://github.com/user-attachments/assets/f88b083e-e18a-4de1-9c64-8dac8790e41b">
