### PR TITLE
Fix macOS reveal in finder action

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -366,7 +366,7 @@ export function revealFile(p:string){
 		cmd = `explorer.exe /select,${p}`
 	}
 	else if(process.platform == "darwin"){
-		cmd = `open -r ${p}`
+		cmd = `open -R ${p}`
 	}
 	else{
 		p = path.parse(p).dir;


### PR DESCRIPTION
In macOS the flag for revealing a file in finder is -R, not -r. Current behavior when clicking this action is a no-op. [source](https://ss64.com/mac/open.html)